### PR TITLE
fix: use slash_safe and HTTPS for OSS signed URLs

### DIFF
--- a/src/utils/oss_utils.py
+++ b/src/utils/oss_utils.py
@@ -221,8 +221,12 @@ class OSSImageUploader:
                 if now - timestamp < (expires - 600):
                     return cached_url
 
-            url = self.bucket.sign_url('GET', object_key, expires)
-            
+            url = self.bucket.sign_url('GET', object_key, expires, slash_safe=True)
+
+            # Ensure HTTPS - some AI APIs (e.g. DashScope wan2.6-i2v) require HTTPS
+            if url.startswith("http://"):
+                url = "https://" + url[7:]
+
             # Update cache
             self._url_cache[cache_key] = (url, now)
             return url


### PR DESCRIPTION
## Summary
- Fix wan2.6-i2v "Failed to download" error caused by OSS signed URLs having URL-encoded slashes (`%2F`) and using HTTP instead of HTTPS
- Add `slash_safe=True` to `bucket.sign_url()` to preserve `/` in object key paths
- Force HTTPS on all generated signed URLs for AI API compatibility

## Root Cause
`oss2.Bucket.sign_url()` defaults to encoding `/` as `%2F` in the object key path, producing URLs like:
```
http://bucket.oss-region.aliyuncs.com/path%2Fto%2Ffile.png?...
```
DashScope's wan2.6-i2v service cannot resolve these encoded paths when downloading input images.

## Test plan
- [ ] Generate video with wan2.6-i2v using OSS-hosted input image
- [ ] Verify signed URLs use HTTPS and have unencoded path slashes
- [ ] Verify wan2.5-t2v (no image) still works
- [ ] Verify frontend image display (sign_url_for_display) still works