### PR TITLE
fix(image): support local Wan 2.6 reference images without OSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,14 +96,19 @@ static/
 # Internal development tools (not for public repo)
 .agent/
 .claude/
+.superset/
 GITHUB_RELEASE_CHECKLIST.md
 CLAUDE.md
+AGENTS.md
 demand/
+
+# Local docs scratchpads
+docs/api-reference/
+docs/plans/
 
 # Build/packaging configs (keep templates only)
 *.spec
 !build.spec.template
-
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ static/
 # Internal development tools (not for public repo)
 .agent/
 .claude/
+.codex/
 .superset/
 GITHUB_RELEASE_CHECKLIST.md
 CLAUDE.md
@@ -109,6 +110,5 @@ docs/plans/
 # Build/packaging configs (keep templates only)
 *.spec
 !build.spec.template
-
 
 

--- a/src/models/image.py
+++ b/src/models/image.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Tuple
+import base64
+import mimetypes
 import os
 import time
 import requests
@@ -200,8 +202,8 @@ class WanxImageModel(ImageGenModel):
             "X-DashScope-Async": "enable"  # Required for async mode
         }
         
-        # Build content array with text and reference images
-        content = [{"text": prompt}]
+        # Build content array with reference images and prompt text
+        content = []
         
         # Add reference images (upload to OSS first if local paths)
         if ref_image_paths:
@@ -209,36 +211,17 @@ class WanxImageModel(ImageGenModel):
             # This method is specifically for wan2.6-image which supports 4 images
             ref_limit = 4
             for path in ref_image_paths[:ref_limit]:
-                if os.path.exists(path):
-                    # Upload local file to OSS and get signed URL for AI API
-                    uploader = OSSImageUploader()
-                    if uploader.is_configured:
-                        object_key = uploader.upload_file(path, sub_path="temp/ref_images")
-                        if object_key:
-                            # Generate signed URL for AI API access (30 min validity)
-                            signed_url = uploader.sign_url_for_api(object_key)
-                            content.append({"image": signed_url})
-                            logger.info(f"Reference image uploaded, signed URL: {signed_url[:80]}...")
-                    else:
-                        # OSS not configured, try to use local path (will likely fail for remote APIs)
-                        logger.warning(f"OSS not configured, cannot upload reference image: {path}")
-                elif path.startswith("http"):
-                    # Already a URL (could be signed or public)
-                    content.append({"image": path})
-                else:
-                    # Check if it's an OSS Object Key using the utility function
-                    from ..utils.oss_utils import is_object_key
-                    if is_object_key(path):
-                        uploader = OSSImageUploader()
-                        if uploader.is_configured:
-                            # Generate signed URL for AI API access (30 min validity)
-                            signed_url = uploader.sign_url_for_api(path)
-                            content.append({"image": signed_url})
-                            logger.info(f"Reference image (Object Key), signed URL: {signed_url[:80]}...")
-                        else:
-                            logger.warning(f"OSS not configured but Object Key provided: {path}")
-                    else:
-                        logger.warning(f"Reference image not found: {path}")
+                image_input = self._resolve_wan26_reference_image(path)
+                if image_input:
+                    content.append({"image": image_input})
+
+        if ref_image_paths and not content:
+            raise RuntimeError(
+                "Wan 2.6 Image requires at least one usable reference image. "
+                "Please provide a valid local image, public URL, or configure OSS."
+            )
+
+        content.append({"text": prompt})
         
         payload = {
             "model": "wan2.6-image",
@@ -349,6 +332,48 @@ class WanxImageModel(ImageGenModel):
             # PENDING or RUNNING - continue polling
         
         raise RuntimeError(f"Wan 2.6 Image task timed out after {max_wait_time}s")
+
+    def _resolve_wan26_reference_image(self, path: str) -> str:
+        if os.path.exists(path):
+            uploader = OSSImageUploader()
+            if uploader.is_configured:
+                object_key = uploader.upload_file(path, sub_path="temp/ref_images")
+                if object_key:
+                    signed_url = uploader.sign_url_for_api(object_key)
+                    logger.info(f"Reference image uploaded, signed URL: {signed_url[:80]}...")
+                    return signed_url
+
+            data_uri = self._encode_local_image_as_data_uri(path)
+            logger.info("OSS not configured, using base64 data URI for local reference image")
+            return data_uri
+
+        if path.startswith("http"):
+            return path
+
+        from ..utils.oss_utils import is_object_key
+
+        if is_object_key(path):
+            uploader = OSSImageUploader()
+            if uploader.is_configured:
+                signed_url = uploader.sign_url_for_api(path)
+                logger.info(f"Reference image (Object Key), signed URL: {signed_url[:80]}...")
+                return signed_url
+
+            logger.warning(f"OSS not configured but Object Key provided: {path}")
+            return None
+
+        logger.warning(f"Reference image not found: {path}")
+        return None
+
+    def _encode_local_image_as_data_uri(self, path: str) -> str:
+        mime_type, _ = mimetypes.guess_type(path)
+        if not mime_type:
+            mime_type = "image/png"
+
+        with open(path, "rb") as image_file:
+            encoded = base64.b64encode(image_file.read()).decode("ascii")
+
+        return f"data:{mime_type};base64,{encoded}"
 
     def _generate_sdk(self, prompt: str, model_name: str, size: str, n: int, negative_prompt: str, all_ref_paths: list, kwargs: dict) -> str:
         """Generate image using Dashscope SDK (for older models)."""

--- a/tests/test_wan26_image_refs.py
+++ b/tests/test_wan26_image_refs.py
@@ -1,0 +1,84 @@
+import base64
+
+import requests
+
+from src.models.image import WanxImageModel
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+"
+    "X2VINQAAAABJRU5ErkJggg=="
+)
+
+
+class TestWan26ImageLocalReferenceFallback:
+    def test_local_reference_image_uses_base64_payload_without_oss(self, monkeypatch, tmp_path):
+        ref_path = tmp_path / "reference.png"
+        ref_path.write_bytes(base64.b64decode(PNG_1X1_BASE64))
+
+        captured_payload = {}
+
+        class FakeUploader:
+            def __init__(self):
+                self.is_configured = False
+
+        class FakeCreateResponse:
+            status_code = 200
+            text = (
+                '{"request_id":"req-1","output":{"task_id":"task-1","task_status":"PENDING"}}'
+            )
+
+            def json(self):
+                return {
+                    "request_id": "req-1",
+                    "output": {"task_id": "task-1", "task_status": "PENDING"},
+                }
+
+        class FakePollResponse:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "output": {
+                        "task_status": "SUCCEEDED",
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": [{"image": "https://example.com/generated.png"}]
+                                }
+                            }
+                        ],
+                    }
+                }
+
+        def fake_post(url, headers=None, json=None, timeout=None):
+            captured_payload["json"] = json
+            return FakeCreateResponse()
+
+        def fake_get(url, headers=None, timeout=None):
+            return FakePollResponse()
+
+        monkeypatch.setattr("src.models.image.OSSImageUploader", FakeUploader)
+        monkeypatch.setattr("src.models.image.get_provider_base_url", lambda _: "https://dashscope.test")
+        monkeypatch.setattr(requests, "post", fake_post)
+        monkeypatch.setattr(requests, "get", fake_get)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        model = WanxImageModel({"params": {"i2i_model_name": "wan2.6-image"}})
+
+        image_url = model._generate_wan26_image_http(
+            prompt="keep the same character",
+            size="1280*1280",
+            n=1,
+            negative_prompt="bad anatomy",
+            ref_image_paths=[str(ref_path)],
+        )
+
+        assert image_url == "https://example.com/generated.png"
+
+        content = captured_payload["json"]["input"]["messages"][0]["content"]
+        image_entries = [item for item in content if "image" in item]
+
+        assert len(image_entries) == 1
+        assert image_entries[0]["image"].startswith("data:image/png;base64,")
+        assert content[-1]["text"] == "keep the same character"


### PR DESCRIPTION
## Summary
- support local reference images for Wan 2.6 image editing when OSS is not configured
- add a regression test for the local base64 fallback path
- ignore local workspace artifacts used during development

## Test plan
- [x] HOME=/tmp/lumenx-test-home pytest tests -q