### PR TITLE
feat: 支持无 OSS 的本地优先媒体回退与 Provider 路由

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,22 @@ git checkout -b feature/your-feature-name
 - `refactor/description` - Code refactoring
 - `test/description` - Test additions or updates
 
+## 🧭 Media Storage & Provider Routing Rules
+
+When contributing to media upload/generation flows, please keep these invariants:
+
+- **Local-first storage**: files under `output/` are always written first and remain the durable project source.
+- **OSS is optional**: OSS acts as an optional mirror and signed-URL service, not a mandatory storage backend.
+- **DashScope-first backend**: for supported model families, DashScope is the default provider backend.
+- **Vendor-direct remains available**: Kling/Vidu vendor APIs are still supported when users opt in and configure vendor credentials.
+
+Use the following vocabulary consistently in PRs, code, and docs:
+
+- `storage_mode`: `local_only` or `local_plus_oss`
+- `provider_backend`: `dashscope` or `vendor`
+- `media_ref`: stable project-side media reference (for example local relative path or OSS object key)
+- `resolved_media_input`: request-side provider-ready payload derived from `media_ref`
+
 ## 📝 Code Style Guidelines
 
 ### Python Code (Backend)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,52 @@ npm install && npm run dev
 
 ---
 
+## 🧩 运行模式与必填配置
+
+LumenX 采用 **本地优先（local-first）** 的媒体存储逻辑：
+
+- 所有上传/生成媒体都会先写入 `output/`，作为稳定项目数据源。
+- OSS 是可选镜像与签名 URL 服务，不是必选前置依赖。
+- 提供商路由默认走 DashScope（可按模型家族切换到 vendor-direct）。
+
+### 模式 1：DashScope-only（无 OSS）
+
+- 用途：单机本地创作，不配置 OSS，也不配置原厂 Kling/Vidu Key。
+- 必填：`DASHSCOPE_API_KEY`
+- 可选：`KLING_PROVIDER_MODE`、`VIDU_PROVIDER_MODE`（默认 `dashscope`）
+
+### 模式 2：DashScope + OSS（本地 + 云镜像）
+
+- 用途：本地持久化 + OSS 备份/签名 URL。
+- 必填：
+  - `DASHSCOPE_API_KEY`
+  - `ALIBABA_CLOUD_ACCESS_KEY_ID`
+  - `ALIBABA_CLOUD_ACCESS_KEY_SECRET`
+  - `OSS_BUCKET_NAME`
+  - `OSS_ENDPOINT`
+- 可选：`OSS_BASE_PATH`
+
+### 模式 3：DashScope-first + Kling vendor-direct
+
+- 用途：大部分模型走 DashScope，仅 Kling 走原厂。
+- 必填：
+  - `DASHSCOPE_API_KEY`
+  - `KLING_PROVIDER_MODE=vendor`
+  - `KLING_ACCESS_KEY`
+  - `KLING_SECRET_KEY`
+- 备注：是否配置 OSS 取决于你的存储需求，不影响该模式可用性。
+
+### 模式 4：DashScope-first + Vidu vendor-direct
+
+- 用途：大部分模型走 DashScope，仅 Vidu 走原厂。
+- 必填：
+  - `DASHSCOPE_API_KEY`
+  - `VIDU_PROVIDER_MODE=vendor`
+  - `VIDU_API_KEY`
+- 备注：是否配置 OSS 取决于你的存储需求，不影响该模式可用性。
+
+---
+
 ## ⚙️ 进阶配置
 
 <details>
@@ -222,4 +268,3 @@ lumenx/
 <div align="center">
   Made with ❤️ by Alibaba Group
 </div>
-

--- a/README_EN.md
+++ b/README_EN.md
@@ -156,6 +156,52 @@ npm install && npm run dev
 
 ---
 
+## 🧩 Operating Modes & Required Variables
+
+LumenX uses a **local-first** media storage strategy:
+
+- Uploaded/generated media is always written to `output/` first as the durable project source.
+- OSS is optional (mirror + signed URL service), not a required prerequisite.
+- Provider routing defaults to DashScope and can be overridden per model family.
+
+### Mode 1: DashScope-only (No OSS)
+
+- Use case: local-only creation without OSS and without vendor-direct Kling/Vidu keys.
+- Required: `DASHSCOPE_API_KEY`
+- Optional: `KLING_PROVIDER_MODE`, `VIDU_PROVIDER_MODE` (default is `dashscope`)
+
+### Mode 2: DashScope + OSS (Local + Cloud Mirror)
+
+- Use case: local persistence with OSS backup/signing capability.
+- Required:
+  - `DASHSCOPE_API_KEY`
+  - `ALIBABA_CLOUD_ACCESS_KEY_ID`
+  - `ALIBABA_CLOUD_ACCESS_KEY_SECRET`
+  - `OSS_BUCKET_NAME`
+  - `OSS_ENDPOINT`
+- Optional: `OSS_BASE_PATH`
+
+### Mode 3: DashScope-first + Kling Vendor-direct
+
+- Use case: most models run through DashScope, while Kling runs against vendor API.
+- Required:
+  - `DASHSCOPE_API_KEY`
+  - `KLING_PROVIDER_MODE=vendor`
+  - `KLING_ACCESS_KEY`
+  - `KLING_SECRET_KEY`
+- Note: OSS remains optional and independent from this routing mode.
+
+### Mode 4: DashScope-first + Vidu Vendor-direct
+
+- Use case: most models run through DashScope, while Vidu runs against vendor API.
+- Required:
+  - `DASHSCOPE_API_KEY`
+  - `VIDU_PROVIDER_MODE=vendor`
+  - `VIDU_API_KEY`
+- Note: OSS remains optional and independent from this routing mode.
+
+---
+
 ## ⚙️ Advanced Configuration
 
 <details>

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -55,6 +55,53 @@ LumenX 使用阿里云灵积平台(DashScope)提供 AI 能力。
 
 ---
 
+## 🧩 运行模式说明（含必填项）
+
+LumenX 的媒体存储是 **本地优先**：
+
+- 所有素材先落盘到 `output/`；
+- OSS 仅在你配置后作为“可选镜像 + 签名 URL”使用；
+- Kling/Vidu 默认跟随 DashScope，可按需切到原厂。
+
+### 模式 1：DashScope-only（推荐起步）
+
+- 适用：不配置 OSS，不走 Kling/Vidu 原厂。
+- 必填：
+  - `DASHSCOPE_API_KEY`
+
+### 模式 2：DashScope + OSS（可选增强）
+
+- 适用：希望保留本地文件，同时在 OSS 做镜像和 URL 服务。
+- 必填：
+  - `DASHSCOPE_API_KEY`
+  - `ALIBABA_CLOUD_ACCESS_KEY_ID`
+  - `ALIBABA_CLOUD_ACCESS_KEY_SECRET`
+  - `OSS_BUCKET_NAME`
+  - `OSS_ENDPOINT`
+- 可选：
+  - `OSS_BASE_PATH`
+
+### 模式 3：DashScope-first + Kling 原厂
+
+- 适用：仅 Kling 走原厂，其它继续走 DashScope。
+- 必填：
+  - `DASHSCOPE_API_KEY`
+  - `KLING_PROVIDER_MODE=vendor`
+  - `KLING_ACCESS_KEY`
+  - `KLING_SECRET_KEY`
+
+### 模式 4：DashScope-first + Vidu 原厂
+
+- 适用：仅 Vidu 走原厂，其它继续走 DashScope。
+- 必填：
+  - `DASHSCOPE_API_KEY`
+  - `VIDU_PROVIDER_MODE=vendor`
+  - `VIDU_API_KEY`
+
+> 提示：是否配置 OSS 与是否选择 Kling/Vidu 原厂是两个独立开关，可组合使用。
+
+---
+
 ## ☁️ OSS 存储配置（可选）
 
 OSS 配置用于云端存储生成的资产，适合团队协作或跨设备使用。

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,6 +24,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+/.npm-cache/
 
 # local env files
 .env*.local

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "14.2.33",
+        "happy-dom": "^20.8.9",
         "jsdom": "^27.0.1",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
@@ -2014,6 +2015,23 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.48.0",
@@ -5009,6 +5027,47 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.anpm.alibaba-inc.com/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node ./scripts/run-vitest.mjs"
   },
   "dependencies": {
     "@react-three/drei": "^9.108.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node ./scripts/run-vitest.mjs"
+    "test": "node ./scripts/run-vitest.mjs",
+    "test:ui": "node ./scripts/run-vitest.mjs --config vitest.ui.config.mts",
+    "test:all": "npm run test && npm run test:ui"
   },
   "dependencies": {
     "@react-three/drei": "^9.108.0",
@@ -32,6 +34,7 @@
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "14.2.33",
+    "happy-dom": "^20.8.9",
     "jsdom": "^27.0.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",

--- a/frontend/scripts/run-vitest.mjs
+++ b/frontend/scripts/run-vitest.mjs
@@ -1,0 +1,25 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const rawArgs = process.argv.slice(2);
+const filteredArgs = rawArgs.filter((arg) => arg !== "--runInBand");
+
+const hasVitestMode = filteredArgs.some((arg) =>
+  arg === "run" || arg === "watch" || arg === "related",
+);
+
+const vitestEntry = path.resolve("node_modules", "vitest", "vitest.mjs");
+const args = [vitestEntry];
+if (!hasVitestMode) {
+  args.push("run");
+}
+args.push(...filteredArgs);
+
+const result = spawnSync(process.execPath, args, {
+  stdio: "inherit",
+});
+
+if (typeof result.status === "number") {
+  process.exit(result.status);
+}
+process.exit(1);

--- a/frontend/src/__tests__/endpoint-config.test.ts
+++ b/frontend/src/__tests__/endpoint-config.test.ts
@@ -85,14 +85,30 @@ function applyEndpointChange(config: EnvConfig, envKey: string, value: string): 
 }
 
 /** Mirrors loadConfig() normalization in dialog/settings */
-function normalizeApiResponse(existing: EnvConfig, data: Partial<EnvConfig> & { [key: string]: unknown }): EnvConfig {
+function normalizeApiResponse(existing: EnvConfig, data: { [key: string]: unknown }): EnvConfig {
+  const base = data as Partial<EnvConfig>;
+
+  const klingMode =
+    typeof data.KLING_PROVIDER_MODE === "string" ? data.KLING_PROVIDER_MODE : existing.KLING_PROVIDER_MODE;
+  const viduMode =
+    typeof data.VIDU_PROVIDER_MODE === "string" ? data.VIDU_PROVIDER_MODE : existing.VIDU_PROVIDER_MODE;
+  const pixverseMode =
+    typeof data.PIXVERSE_PROVIDER_MODE === "string"
+      ? data.PIXVERSE_PROVIDER_MODE
+      : existing.PIXVERSE_PROVIDER_MODE;
+
+  const endpointOverrides =
+    typeof data.endpoint_overrides === "object" && data.endpoint_overrides !== null
+      ? (data.endpoint_overrides as Record<string, string>)
+      : existing.endpoint_overrides ?? {};
+
   return {
     ...existing,
-    ...data,
-    KLING_PROVIDER_MODE: normalizeProviderMode(data.KLING_PROVIDER_MODE ?? existing.KLING_PROVIDER_MODE),
-    VIDU_PROVIDER_MODE: normalizeProviderMode(data.VIDU_PROVIDER_MODE ?? existing.VIDU_PROVIDER_MODE),
-    PIXVERSE_PROVIDER_MODE: normalizeProviderMode(data.PIXVERSE_PROVIDER_MODE ?? existing.PIXVERSE_PROVIDER_MODE),
-    endpoint_overrides: data.endpoint_overrides ?? existing.endpoint_overrides ?? {},
+    ...base,
+    KLING_PROVIDER_MODE: normalizeProviderMode(klingMode),
+    VIDU_PROVIDER_MODE: normalizeProviderMode(viduMode),
+    PIXVERSE_PROVIDER_MODE: normalizeProviderMode(pixverseMode),
+    endpoint_overrides: endpointOverrides,
   };
 }
 

--- a/frontend/src/__tests__/endpoint-config.test.ts
+++ b/frontend/src/__tests__/endpoint-config.test.ts
@@ -1,336 +1,299 @@
 /**
- * Tests for EnvConfigDialog logic: ENDPOINT_PROVIDERS registry,
- * endpoint_overrides handling, validation, and state transforms.
- *
- * Since the project uses vitest environment: 'node' (no jsdom/RTL),
- * we extract and test all pure business logic from EnvConfigDialog.tsx.
+ * Tests for EnvConfig dialog/settings pure logic:
+ * - provider-mode aware required-field validation
+ * - endpoint_overrides state transforms
+ * - API response normalization
+ * - required-dialog canClose behavior
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from "vitest";
 
-// ── Replicated types & constants from EnvConfigDialog.tsx ──────────────
+type ProviderMode = "dashscope" | "vendor";
 
 interface EnvConfig {
-    DASHSCOPE_API_KEY: string;
-    ALIBABA_CLOUD_ACCESS_KEY_ID: string;
-    ALIBABA_CLOUD_ACCESS_KEY_SECRET: string;
-    OSS_BUCKET_NAME: string;
-    OSS_ENDPOINT: string;
-    OSS_BASE_PATH: string;
-    KLING_ACCESS_KEY: string;
-    KLING_SECRET_KEY: string;
-    VIDU_API_KEY: string;
-    endpoint_overrides: Record<string, string>;
-    [key: string]: string | Record<string, string>;
+  DASHSCOPE_API_KEY: string;
+  ALIBABA_CLOUD_ACCESS_KEY_ID: string;
+  ALIBABA_CLOUD_ACCESS_KEY_SECRET: string;
+  OSS_BUCKET_NAME: string;
+  OSS_ENDPOINT: string;
+  OSS_BASE_PATH: string;
+  KLING_PROVIDER_MODE: ProviderMode;
+  VIDU_PROVIDER_MODE: ProviderMode;
+  PIXVERSE_PROVIDER_MODE: ProviderMode;
+  KLING_ACCESS_KEY: string;
+  KLING_SECRET_KEY: string;
+  VIDU_API_KEY: string;
+  endpoint_overrides: Record<string, string>;
+  [key: string]: string | Record<string, string>;
 }
 
 const ENDPOINT_PROVIDERS = [
-    { key: "DASHSCOPE_BASE_URL", label: "DashScope", placeholder: "https://dashscope.aliyuncs.com" },
-    { key: "KLING_BASE_URL", label: "Kling", placeholder: "https://api-beijing.klingai.com/v1" },
-    { key: "VIDU_BASE_URL", label: "Vidu", placeholder: "https://api.vidu.cn/ent/v2" },
+  { key: "DASHSCOPE_BASE_URL", label: "DashScope", placeholder: "https://dashscope.aliyuncs.com" },
+  { key: "KLING_BASE_URL", label: "Kling", placeholder: "https://api-beijing.klingai.com/v1" },
+  { key: "VIDU_BASE_URL", label: "Vidu", placeholder: "https://api.vidu.cn/ent/v2" },
 ];
 
 const DEFAULT_CONFIG: EnvConfig = {
-    DASHSCOPE_API_KEY: "",
-    ALIBABA_CLOUD_ACCESS_KEY_ID: "",
-    ALIBABA_CLOUD_ACCESS_KEY_SECRET: "",
-    OSS_BUCKET_NAME: "",
-    OSS_ENDPOINT: "",
-    OSS_BASE_PATH: "",
-    KLING_ACCESS_KEY: "",
-    KLING_SECRET_KEY: "",
-    VIDU_API_KEY: "",
-    endpoint_overrides: {},
+  DASHSCOPE_API_KEY: "",
+  ALIBABA_CLOUD_ACCESS_KEY_ID: "",
+  ALIBABA_CLOUD_ACCESS_KEY_SECRET: "",
+  OSS_BUCKET_NAME: "",
+  OSS_ENDPOINT: "",
+  OSS_BASE_PATH: "",
+  KLING_PROVIDER_MODE: "dashscope",
+  VIDU_PROVIDER_MODE: "dashscope",
+  PIXVERSE_PROVIDER_MODE: "dashscope",
+  KLING_ACCESS_KEY: "",
+  KLING_SECRET_KEY: "",
+  VIDU_API_KEY: "",
+  endpoint_overrides: {},
 };
 
-// ── Extracted pure functions (same logic as component internals) ────────
+function normalizeProviderMode(mode?: string): ProviderMode {
+  return mode === "vendor" ? "vendor" : "dashscope";
+}
 
-/** Mirrors validateRequiredFields() from EnvConfigDialog */
+/** Mirrors validateRequiredFields() after Task 8 */
 function validateRequiredFields(config: EnvConfig): boolean {
-    const dashscopeKey = (config.DASHSCOPE_API_KEY as string)?.trim();
-    const accessKeyId = (config.ALIBABA_CLOUD_ACCESS_KEY_ID as string)?.trim();
-    const accessKeySecret = (config.ALIBABA_CLOUD_ACCESS_KEY_SECRET as string)?.trim();
-    const ossBucket = (config.OSS_BUCKET_NAME as string)?.trim();
-    const ossEndpoint = (config.OSS_ENDPOINT as string)?.trim();
+  const dashscopeKey = config.DASHSCOPE_API_KEY?.trim();
+  if (!dashscopeKey) return false;
 
-    return !!(dashscopeKey && dashscopeKey.length > 0 &&
-        accessKeyId && accessKeyId.length > 0 &&
-        accessKeySecret && accessKeySecret.length > 0 &&
-        ossBucket && ossBucket.length > 0 &&
-        ossEndpoint && ossEndpoint.length > 0);
+  if (config.KLING_PROVIDER_MODE === "vendor") {
+    const klingAccessKey = config.KLING_ACCESS_KEY?.trim();
+    const klingSecretKey = config.KLING_SECRET_KEY?.trim();
+    if (!klingAccessKey || !klingSecretKey) return false;
+  }
+
+  if (config.VIDU_PROVIDER_MODE === "vendor") {
+    const viduApiKey = config.VIDU_API_KEY?.trim();
+    if (!viduApiKey) return false;
+  }
+
+  return true;
 }
 
 /** Mirrors handleChange() state updater */
 function applyChange(config: EnvConfig, key: string, value: string): EnvConfig {
-    return { ...config, [key]: value };
+  return { ...config, [key]: value };
 }
 
 /** Mirrors handleEndpointChange() state updater */
 function applyEndpointChange(config: EnvConfig, envKey: string, value: string): EnvConfig {
-    return {
-        ...config,
-        endpoint_overrides: { ...config.endpoint_overrides, [envKey]: value },
-    };
+  return {
+    ...config,
+    endpoint_overrides: { ...config.endpoint_overrides, [envKey]: value },
+  };
 }
 
-/** Mirrors loadConfig() data normalization */
-function normalizeApiResponse(existing: EnvConfig, data: Record<string, any>): EnvConfig {
-    return { ...existing, ...data, endpoint_overrides: data.endpoint_overrides ?? {} };
+/** Mirrors loadConfig() normalization in dialog/settings */
+function normalizeApiResponse(existing: EnvConfig, data: Partial<EnvConfig> & { [key: string]: unknown }): EnvConfig {
+  return {
+    ...existing,
+    ...data,
+    KLING_PROVIDER_MODE: normalizeProviderMode(data.KLING_PROVIDER_MODE ?? existing.KLING_PROVIDER_MODE),
+    VIDU_PROVIDER_MODE: normalizeProviderMode(data.VIDU_PROVIDER_MODE ?? existing.VIDU_PROVIDER_MODE),
+    PIXVERSE_PROVIDER_MODE: normalizeProviderMode(data.PIXVERSE_PROVIDER_MODE ?? existing.PIXVERSE_PROVIDER_MODE),
+    endpoint_overrides: data.endpoint_overrides ?? existing.endpoint_overrides ?? {},
+  };
 }
 
-/** Mirrors canClose logic */
+/** Mirrors required-dialog close gating */
 function computeCanClose(isRequired: boolean, config: EnvConfig): boolean {
-    return !isRequired || validateRequiredFields(config);
+  return !isRequired || validateRequiredFields(config);
 }
 
-// ── ENDPOINT_PROVIDERS 注册表 ──────────────────────────────────────────
+describe("ENDPOINT_PROVIDERS registry", () => {
+  it("has key, label, placeholder for each provider", () => {
+    for (const provider of ENDPOINT_PROVIDERS) {
+      expect(provider.key).toBeDefined();
+      expect(provider.label).toBeDefined();
+      expect(provider.placeholder).toBeDefined();
+    }
+  });
 
-describe('ENDPOINT_PROVIDERS 注册表', () => {
-    it('should have key, label, placeholder for each provider', () => {
-        for (const provider of ENDPOINT_PROVIDERS) {
-            expect(provider.key).toBeDefined();
-            expect(provider.label).toBeDefined();
-            expect(provider.placeholder).toBeDefined();
-        }
-    });
+  it("follows {PROVIDER}_BASE_URL naming convention", () => {
+    for (const provider of ENDPOINT_PROVIDERS) {
+      expect(provider.key).toMatch(/^[A-Z]+_BASE_URL$/);
+    }
+  });
 
-    it('should follow {PROVIDER}_BASE_URL naming convention', () => {
-        for (const provider of ENDPOINT_PROVIDERS) {
-            expect(provider.key).toMatch(/^[A-Z]+_BASE_URL$/);
-        }
-    });
+  it("has unique keys", () => {
+    const keys = ENDPOINT_PROVIDERS.map((p) => p.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
 
-    it('should have unique keys', () => {
-        const keys = ENDPOINT_PROVIDERS.map(p => p.key);
-        expect(new Set(keys).size).toBe(keys.length);
-    });
-
-    it('should have valid HTTPS placeholders without trailing slash', () => {
-        for (const provider of ENDPOINT_PROVIDERS) {
-            expect(provider.placeholder).toMatch(/^https:\/\/.+/);
-            expect(provider.placeholder.endsWith('/')).toBe(false);
-        }
-    });
-
-    it('should contain exactly 3 providers (DashScope, Kling, Vidu)', () => {
-        expect(ENDPOINT_PROVIDERS).toHaveLength(3);
-        const labels = ENDPOINT_PROVIDERS.map(p => p.label);
-        expect(labels).toContain('DashScope');
-        expect(labels).toContain('Kling');
-        expect(labels).toContain('Vidu');
-    });
+  it("contains exactly DashScope, Kling, Vidu", () => {
+    expect(ENDPOINT_PROVIDERS).toHaveLength(3);
+    const labels = ENDPOINT_PROVIDERS.map((p) => p.label);
+    expect(labels).toEqual(expect.arrayContaining(["DashScope", "Kling", "Vidu"]));
+  });
 });
 
-// ── validateRequiredFields ─────────────────────────────────────────────
+describe("validateRequiredFields", () => {
+  it("returns false when DashScope key is missing", () => {
+    expect(validateRequiredFields(DEFAULT_CONFIG)).toBe(false);
+  });
 
-describe('validateRequiredFields', () => {
-    it('should return false when all fields are empty', () => {
-        expect(validateRequiredFields(DEFAULT_CONFIG)).toBe(false);
-    });
+  it("returns true when only DashScope key is present (default provider modes)", () => {
+    const valid = { ...DEFAULT_CONFIG, DASHSCOPE_API_KEY: "sk-test" };
+    expect(validateRequiredFields(valid)).toBe(true);
+  });
 
-    it('should return false when only some required fields are filled', () => {
-        const partial = {
-            ...DEFAULT_CONFIG,
-            DASHSCOPE_API_KEY: "sk-test",
-            ALIBABA_CLOUD_ACCESS_KEY_ID: "LTAI5t",
-            // missing: ACCESS_KEY_SECRET, OSS_BUCKET_NAME, OSS_ENDPOINT
-        };
-        expect(validateRequiredFields(partial)).toBe(false);
-    });
-
-    it('should return true when all 5 required fields are filled', () => {
-        const valid = {
-            ...DEFAULT_CONFIG,
-            DASHSCOPE_API_KEY: "sk-test",
-            ALIBABA_CLOUD_ACCESS_KEY_ID: "LTAI5t",
-            ALIBABA_CLOUD_ACCESS_KEY_SECRET: "secret123",
-            OSS_BUCKET_NAME: "my-bucket",
-            OSS_ENDPOINT: "oss-cn-beijing.aliyuncs.com",
-        };
-        expect(validateRequiredFields(valid)).toBe(true);
-    });
-
-    it('should return false when a required field is whitespace-only', () => {
-        const whitespace = {
-            ...DEFAULT_CONFIG,
-            DASHSCOPE_API_KEY: "sk-test",
-            ALIBABA_CLOUD_ACCESS_KEY_ID: "   ",  // whitespace only
-            ALIBABA_CLOUD_ACCESS_KEY_SECRET: "secret123",
-            OSS_BUCKET_NAME: "my-bucket",
-            OSS_ENDPOINT: "oss-cn-beijing.aliyuncs.com",
-        };
-        expect(validateRequiredFields(whitespace)).toBe(false);
-    });
-
-    it('should not require optional fields (KLING, VIDU, OSS_BASE_PATH)', () => {
-        const minimalValid = {
-            ...DEFAULT_CONFIG,
-            DASHSCOPE_API_KEY: "sk-test",
-            ALIBABA_CLOUD_ACCESS_KEY_ID: "LTAI5t",
-            ALIBABA_CLOUD_ACCESS_KEY_SECRET: "secret",
-            OSS_BUCKET_NAME: "bucket",
-            OSS_ENDPOINT: "endpoint",
-            // KLING_ACCESS_KEY, KLING_SECRET_KEY, VIDU_API_KEY, OSS_BASE_PATH all empty
-        };
-        expect(validateRequiredFields(minimalValid)).toBe(true);
-    });
-
-    it('should handle leading/trailing whitespace in valid values', () => {
-        const padded = {
-            ...DEFAULT_CONFIG,
-            DASHSCOPE_API_KEY: "  sk-test  ",
-            ALIBABA_CLOUD_ACCESS_KEY_ID: "  LTAI5t  ",
-            ALIBABA_CLOUD_ACCESS_KEY_SECRET: "  secret  ",
-            OSS_BUCKET_NAME: "  bucket  ",
-            OSS_ENDPOINT: "  endpoint  ",
-        };
-        expect(validateRequiredFields(padded)).toBe(true);
-    });
-});
-
-// ── handleChange (state transform) ─────────────────────────────────────
-
-describe('applyChange (handleChange logic)', () => {
-    it('should update a single field immutably', () => {
-        const updated = applyChange(DEFAULT_CONFIG, "DASHSCOPE_API_KEY", "sk-new");
-        expect(updated.DASHSCOPE_API_KEY).toBe("sk-new");
-        expect(DEFAULT_CONFIG.DASHSCOPE_API_KEY).toBe("");  // original unchanged
-    });
-
-    it('should preserve other fields when updating one', () => {
-        const base = { ...DEFAULT_CONFIG, VIDU_API_KEY: "existing" };
-        const updated = applyChange(base, "DASHSCOPE_API_KEY", "sk-new");
-        expect(updated.VIDU_API_KEY).toBe("existing");
-        expect(updated.DASHSCOPE_API_KEY).toBe("sk-new");
-    });
-
-    it('should preserve endpoint_overrides when updating a key field', () => {
-        const base = {
-            ...DEFAULT_CONFIG,
-            endpoint_overrides: { DASHSCOPE_BASE_URL: "https://custom.com" },
-        };
-        const updated = applyChange(base, "DASHSCOPE_API_KEY", "sk-new");
-        expect(updated.endpoint_overrides).toEqual({ DASHSCOPE_BASE_URL: "https://custom.com" });
-    });
-});
-
-// ── handleEndpointChange (state transform) ─────────────────────────────
-
-describe('applyEndpointChange (handleEndpointChange logic)', () => {
-    it('should add a new endpoint override', () => {
-        const updated = applyEndpointChange(DEFAULT_CONFIG, "DASHSCOPE_BASE_URL", "https://intl.example.com");
-        expect(updated.endpoint_overrides["DASHSCOPE_BASE_URL"]).toBe("https://intl.example.com");
-    });
-
-    it('should update an existing endpoint override', () => {
-        const base = {
-            ...DEFAULT_CONFIG,
-            endpoint_overrides: { DASHSCOPE_BASE_URL: "https://old.com" },
-        };
-        const updated = applyEndpointChange(base, "DASHSCOPE_BASE_URL", "https://new.com");
-        expect(updated.endpoint_overrides["DASHSCOPE_BASE_URL"]).toBe("https://new.com");
-    });
-
-    it('should preserve other overrides when updating one', () => {
-        const base = {
-            ...DEFAULT_CONFIG,
-            endpoint_overrides: {
-                DASHSCOPE_BASE_URL: "https://ds.com",
-                KLING_BASE_URL: "https://kling.com",
-            },
-        };
-        const updated = applyEndpointChange(base, "DASHSCOPE_BASE_URL", "https://new-ds.com");
-        expect(updated.endpoint_overrides["DASHSCOPE_BASE_URL"]).toBe("https://new-ds.com");
-        expect(updated.endpoint_overrides["KLING_BASE_URL"]).toBe("https://kling.com");
-    });
-
-    it('should allow clearing an override by setting empty string', () => {
-        const base = {
-            ...DEFAULT_CONFIG,
-            endpoint_overrides: { DASHSCOPE_BASE_URL: "https://custom.com" },
-        };
-        const updated = applyEndpointChange(base, "DASHSCOPE_BASE_URL", "");
-        expect(updated.endpoint_overrides["DASHSCOPE_BASE_URL"]).toBe("");
-    });
-
-    it('should not mutate original config', () => {
-        const original = {
-            ...DEFAULT_CONFIG,
-            endpoint_overrides: { KLING_BASE_URL: "https://kling.com" },
-        };
-        const originalOverrides = { ...original.endpoint_overrides };
-        applyEndpointChange(original, "VIDU_BASE_URL", "https://vidu.com");
-        expect(original.endpoint_overrides).toEqual(originalOverrides);
-    });
-});
-
-// ── normalizeApiResponse (loadConfig logic) ────────────────────────────
-
-describe('normalizeApiResponse (loadConfig data normalization)', () => {
-    it('should merge API data into existing config', () => {
-        const apiData = { DASHSCOPE_API_KEY: "sk-from-api", endpoint_overrides: {} };
-        const result = normalizeApiResponse(DEFAULT_CONFIG, apiData);
-        expect(result.DASHSCOPE_API_KEY).toBe("sk-from-api");
-    });
-
-    it('should fallback endpoint_overrides to {} when undefined in response', () => {
-        const apiData = { DASHSCOPE_API_KEY: "sk-test" }; // no endpoint_overrides
-        const result = normalizeApiResponse(DEFAULT_CONFIG, apiData);
-        expect(result.endpoint_overrides).toEqual({});
-    });
-
-    it('should fallback endpoint_overrides to {} when null in response', () => {
-        const apiData = { DASHSCOPE_API_KEY: "sk-test", endpoint_overrides: null };
-        const result = normalizeApiResponse(DEFAULT_CONFIG, apiData);
-        expect(result.endpoint_overrides).toEqual({});
-    });
-
-    it('should preserve endpoint_overrides from API response', () => {
-        const apiData = {
-            DASHSCOPE_API_KEY: "sk-test",
-            endpoint_overrides: { DASHSCOPE_BASE_URL: "https://intl.example.com" },
-        };
-        const result = normalizeApiResponse(DEFAULT_CONFIG, apiData);
-        expect(result.endpoint_overrides).toEqual({ DASHSCOPE_BASE_URL: "https://intl.example.com" });
-    });
-
-    it('should preserve existing config fields not in API response', () => {
-        const existing = { ...DEFAULT_CONFIG, KLING_ACCESS_KEY: "local-key" };
-        const apiData = { DASHSCOPE_API_KEY: "sk-api", endpoint_overrides: {} };
-        const result = normalizeApiResponse(existing, apiData);
-        expect(result.KLING_ACCESS_KEY).toBe("local-key");
-        expect(result.DASHSCOPE_API_KEY).toBe("sk-api");
-    });
-
-    it('should override existing fields with API response values', () => {
-        const existing = { ...DEFAULT_CONFIG, DASHSCOPE_API_KEY: "old-key" };
-        const apiData = { DASHSCOPE_API_KEY: "new-key", endpoint_overrides: {} };
-        const result = normalizeApiResponse(existing, apiData);
-        expect(result.DASHSCOPE_API_KEY).toBe("new-key");
-    });
-});
-
-// ── canClose logic ─────────────────────────────────────────────────────
-
-describe('computeCanClose', () => {
-    const validConfig = {
-        ...DEFAULT_CONFIG,
-        DASHSCOPE_API_KEY: "sk-test",
-        ALIBABA_CLOUD_ACCESS_KEY_ID: "LTAI5t",
-        ALIBABA_CLOUD_ACCESS_KEY_SECRET: "secret",
-        OSS_BUCKET_NAME: "bucket",
-        OSS_ENDPOINT: "endpoint",
+  it("does not require OSS or Alibaba credentials", () => {
+    const valid = {
+      ...DEFAULT_CONFIG,
+      DASHSCOPE_API_KEY: "sk-test",
+      ALIBABA_CLOUD_ACCESS_KEY_ID: "",
+      ALIBABA_CLOUD_ACCESS_KEY_SECRET: "",
+      OSS_BUCKET_NAME: "",
+      OSS_ENDPOINT: "",
     };
+    expect(validateRequiredFields(valid)).toBe(true);
+  });
 
-    it('should return true when isRequired is false regardless of config', () => {
-        expect(computeCanClose(false, DEFAULT_CONFIG)).toBe(true);
-        expect(computeCanClose(false, validConfig)).toBe(true);
-    });
+  it("requires Kling vendor credentials when KLING_PROVIDER_MODE=vendor", () => {
+    const invalid = {
+      ...DEFAULT_CONFIG,
+      DASHSCOPE_API_KEY: "sk-test",
+      KLING_PROVIDER_MODE: "vendor" as const,
+      KLING_ACCESS_KEY: "",
+      KLING_SECRET_KEY: "",
+    };
+    expect(validateRequiredFields(invalid)).toBe(false);
 
-    it('should return false when isRequired and config is invalid', () => {
-        expect(computeCanClose(true, DEFAULT_CONFIG)).toBe(false);
-    });
+    const valid = {
+      ...invalid,
+      KLING_ACCESS_KEY: "kling-ak",
+      KLING_SECRET_KEY: "kling-sk",
+    };
+    expect(validateRequiredFields(valid)).toBe(true);
+  });
 
-    it('should return true when isRequired and config is valid', () => {
-        expect(computeCanClose(true, validConfig)).toBe(true);
+  it("requires Vidu API key when VIDU_PROVIDER_MODE=vendor", () => {
+    const invalid = {
+      ...DEFAULT_CONFIG,
+      DASHSCOPE_API_KEY: "sk-test",
+      VIDU_PROVIDER_MODE: "vendor" as const,
+      VIDU_API_KEY: "",
+    };
+    expect(validateRequiredFields(invalid)).toBe(false);
+
+    const valid = {
+      ...invalid,
+      VIDU_API_KEY: "vidu-key",
+    };
+    expect(validateRequiredFields(valid)).toBe(true);
+  });
+
+  it("trims whitespace before validation", () => {
+    const invalid = {
+      ...DEFAULT_CONFIG,
+      DASHSCOPE_API_KEY: "   ",
+    };
+    expect(validateRequiredFields(invalid)).toBe(false);
+
+    const valid = {
+      ...DEFAULT_CONFIG,
+      DASHSCOPE_API_KEY: "  sk-test  ",
+      KLING_PROVIDER_MODE: "vendor" as const,
+      KLING_ACCESS_KEY: " kling-ak ",
+      KLING_SECRET_KEY: " kling-sk ",
+      VIDU_PROVIDER_MODE: "vendor" as const,
+      VIDU_API_KEY: " vidu-key ",
+    };
+    expect(validateRequiredFields(valid)).toBe(true);
+  });
+});
+
+describe("applyChange (handleChange logic)", () => {
+  it("updates a single field immutably", () => {
+    const updated = applyChange(DEFAULT_CONFIG, "DASHSCOPE_API_KEY", "sk-new");
+    expect(updated.DASHSCOPE_API_KEY).toBe("sk-new");
+    expect(DEFAULT_CONFIG.DASHSCOPE_API_KEY).toBe("");
+  });
+
+  it("preserves provider mode fields when changing key values", () => {
+    const base = { ...DEFAULT_CONFIG, KLING_PROVIDER_MODE: "vendor" as const };
+    const updated = applyChange(base, "DASHSCOPE_API_KEY", "sk-new");
+    expect(updated.KLING_PROVIDER_MODE).toBe("vendor");
+  });
+});
+
+describe("applyEndpointChange (handleEndpointChange logic)", () => {
+  it("adds and updates endpoint overrides immutably", () => {
+    const added = applyEndpointChange(DEFAULT_CONFIG, "DASHSCOPE_BASE_URL", "https://intl.example.com");
+    expect(added.endpoint_overrides.DASHSCOPE_BASE_URL).toBe("https://intl.example.com");
+
+    const updated = applyEndpointChange(added, "DASHSCOPE_BASE_URL", "https://new.example.com");
+    expect(updated.endpoint_overrides.DASHSCOPE_BASE_URL).toBe("https://new.example.com");
+    expect(added.endpoint_overrides.DASHSCOPE_BASE_URL).toBe("https://intl.example.com");
+  });
+
+  it("preserves other overrides when changing one", () => {
+    const base = {
+      ...DEFAULT_CONFIG,
+      endpoint_overrides: {
+        DASHSCOPE_BASE_URL: "https://ds.example.com",
+        KLING_BASE_URL: "https://kling.example.com",
+      },
+    };
+    const updated = applyEndpointChange(base, "VIDU_BASE_URL", "https://vidu.example.com");
+    expect(updated.endpoint_overrides.KLING_BASE_URL).toBe("https://kling.example.com");
+    expect(updated.endpoint_overrides.VIDU_BASE_URL).toBe("https://vidu.example.com");
+  });
+});
+
+describe("normalizeApiResponse", () => {
+  it("preserves provider-mode fields from API response", () => {
+    const apiData = {
+      DASHSCOPE_API_KEY: "sk-from-api",
+      KLING_PROVIDER_MODE: "vendor",
+      VIDU_PROVIDER_MODE: "vendor",
+      PIXVERSE_PROVIDER_MODE: "dashscope",
+      endpoint_overrides: { KLING_BASE_URL: "https://custom-kling.example.com" },
+    };
+    const result = normalizeApiResponse(DEFAULT_CONFIG, apiData);
+    expect(result.KLING_PROVIDER_MODE).toBe("vendor");
+    expect(result.VIDU_PROVIDER_MODE).toBe("vendor");
+    expect(result.endpoint_overrides).toEqual({ KLING_BASE_URL: "https://custom-kling.example.com" });
+  });
+
+  it("falls back missing or invalid provider modes to dashscope", () => {
+    const result = normalizeApiResponse(DEFAULT_CONFIG, {
+      KLING_PROVIDER_MODE: "unexpected-value",
+      endpoint_overrides: {},
     });
+    expect(result.KLING_PROVIDER_MODE).toBe("dashscope");
+    expect(result.VIDU_PROVIDER_MODE).toBe("dashscope");
+    expect(result.PIXVERSE_PROVIDER_MODE).toBe("dashscope");
+  });
+
+  it("preserves existing endpoint overrides when API omits endpoint_overrides", () => {
+    const existing = {
+      ...DEFAULT_CONFIG,
+      endpoint_overrides: { DASHSCOPE_BASE_URL: "https://existing.example.com" },
+    };
+    const result = normalizeApiResponse(existing, { DASHSCOPE_API_KEY: "sk-updated" });
+    expect(result.endpoint_overrides).toEqual({ DASHSCOPE_BASE_URL: "https://existing.example.com" });
+  });
+});
+
+describe("computeCanClose", () => {
+  it("returns true when dialog is not required", () => {
+    expect(computeCanClose(false, DEFAULT_CONFIG)).toBe(true);
+  });
+
+  it("blocks closing required dialog until DashScope key is set", () => {
+    expect(computeCanClose(true, DEFAULT_CONFIG)).toBe(false);
+    const valid = { ...DEFAULT_CONFIG, DASHSCOPE_API_KEY: "sk-test" };
+    expect(computeCanClose(true, valid)).toBe(true);
+  });
+
+  it("blocks closing required dialog in vendor mode when vendor keys are missing", () => {
+    const invalid = {
+      ...DEFAULT_CONFIG,
+      DASHSCOPE_API_KEY: "sk-test",
+      KLING_PROVIDER_MODE: "vendor" as const,
+    };
+    expect(computeCanClose(true, invalid)).toBe(false);
+  });
 });

--- a/frontend/src/__tests__/video-params.test.ts
+++ b/frontend/src/__tests__/video-params.test.ts
@@ -211,9 +211,9 @@ describe('GRID_COLS_CLASS', () => {
                 usedCounts.add(model.duration.options.length);
             }
         }
-        for (const count of usedCounts) {
+        usedCounts.forEach((count) => {
             expect(GRID_COLS_CLASS[count]).toBeDefined();
-        }
+        });
     });
 });
 

--- a/frontend/src/components/EnvConfigChecker.tsx
+++ b/frontend/src/components/EnvConfigChecker.tsx
@@ -22,12 +22,7 @@ export default function EnvConfigChecker() {
       const config = await api.getEnvConfig();
       // 空值和空字符串都视为未配置
       const dashscopeKey = config.DASHSCOPE_API_KEY?.trim();
-      const accessKeyId = config.ALIBABA_CLOUD_ACCESS_KEY_ID?.trim();
-      const accessKeySecret = config.ALIBABA_CLOUD_ACCESS_KEY_SECRET?.trim();
-      
-      const hasRequired = dashscopeKey && dashscopeKey.length > 0 &&
-                         accessKeyId && accessKeyId.length > 0 &&
-                         accessKeySecret && accessKeySecret.length > 0;
+      const hasRequired = dashscopeKey && dashscopeKey.length > 0;
       
       if (!hasRequired) {
         setEnvRequired(true);

--- a/frontend/src/components/modules/ArtDirection.tsx
+++ b/frontend/src/components/modules/ArtDirection.tsx
@@ -85,11 +85,26 @@ export default function ArtDirection() {
         }
     };
 
-    const handleSelectStyle = (style: StyleConfig) => {
-        setSelectedStyle(style);
-        setEditingName(style.name);
-        setEditingPositive(style.positive_prompt);
-        setEditingNegative(style.negative_prompt);
+    const toStyleConfig = (style: StyleConfig | StylePreset): StyleConfig => {
+        if ("positive_prompt" in style) {
+            return style;
+        }
+
+        return {
+            id: style.id,
+            name: style.name,
+            positive_prompt: style.prompt,
+            negative_prompt: style.negative_prompt || "",
+            is_custom: false,
+        };
+    };
+
+    const handleSelectStyle = (style: StyleConfig | StylePreset) => {
+        const normalizedStyle = toStyleConfig(style);
+        setSelectedStyle(normalizedStyle);
+        setEditingName(normalizedStyle.name);
+        setEditingPositive(normalizedStyle.positive_prompt);
+        setEditingNegative(normalizedStyle.negative_prompt);
     };
 
     const handleSaveCustom = async () => {

--- a/frontend/src/components/modules/ConsistencyVault.tsx
+++ b/frontend/src/components/modules/ConsistencyVault.tsx
@@ -460,7 +460,7 @@ export default function ConsistencyVault() {
                             generatingTypes={getAssetGeneratingTypes(selectedAssetId)}
                             stylePrompt={currentProject?.art_direction?.style_config?.positive_prompt || ""}
                             styleNegativePrompt={currentProject?.art_direction?.style_config?.negative_prompt || ""}
-                            onGenerateVideo={(prompt: string, duration: number, subType: string) => handleGenerateVideo(selectedAssetId, selectedAssetType, prompt, duration, subType)}
+                            onGenerateVideo={(prompt: string, duration: number, subType?: string) => handleGenerateVideo(selectedAssetId, selectedAssetType, prompt, duration, subType || "video")}
                             onDeleteVideo={(videoId: string) => handleDeleteVideo(selectedAssetId, selectedAssetType, videoId)}
                         />
                     ) : (

--- a/frontend/src/components/modules/StoryboardComposer.tsx
+++ b/frontend/src/components/modules/StoryboardComposer.tsx
@@ -282,20 +282,9 @@ export default function StoryboardComposer() {
                 });
             }
 
-            // Construct Enhanced Prompt using Art Direction (or fallback to legacy)
+            // Construct enhanced prompt using Art Direction style config.
             const artDirection = currentProject?.art_direction;
-            let globalStylePrompt = "";
-
-            if (artDirection?.style_config) {
-                // Use Art Direction style
-                globalStylePrompt = artDirection.style_config.positive_prompt;
-            } else {
-                // Fallback to legacy style system
-                const styles = useProjectStore.getState().styles;
-                const selectedStyleId = useProjectStore.getState().selectedStyleId;
-                const currentStyle = styles.find(s => s.id === selectedStyleId);
-                globalStylePrompt = currentStyle?.prompt || "";
-            }
+            const globalStylePrompt = artDirection?.style_config?.positive_prompt || "";
 
             // Construct final prompt:
             // If image_prompt exists (polished or manually edited), it already contains action/dialogue,

--- a/frontend/src/components/project/EnvConfigDialog.tsx
+++ b/frontend/src/components/project/EnvConfigDialog.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, Save, Settings, ChevronDown, ChevronRight, Loader2, Key } from "lucide-react";
-import { api } from "@/lib/api";
+import { X, Save, ChevronDown, ChevronRight, Loader2, Key } from "lucide-react";
+import { api, type EnvConfigPayload, type ProviderMode } from "@/lib/api";
 
 interface EnvConfigDialogProps {
   isOpen: boolean;
@@ -11,19 +11,21 @@ interface EnvConfigDialogProps {
   isRequired?: boolean;
 }
 
-interface EnvConfig {
+type EnvConfig = EnvConfigPayload & {
   DASHSCOPE_API_KEY: string;
   ALIBABA_CLOUD_ACCESS_KEY_ID: string;
   ALIBABA_CLOUD_ACCESS_KEY_SECRET: string;
   OSS_BUCKET_NAME: string;
   OSS_ENDPOINT: string;
   OSS_BASE_PATH: string;
+  KLING_PROVIDER_MODE: ProviderMode;
+  VIDU_PROVIDER_MODE: ProviderMode;
+  PIXVERSE_PROVIDER_MODE: ProviderMode;
   KLING_ACCESS_KEY: string;
   KLING_SECRET_KEY: string;
   VIDU_API_KEY: string;
   endpoint_overrides: Record<string, string>;
-  [key: string]: string | Record<string, string>;
-}
+};
 
 const ENDPOINT_PROVIDERS = [
   { key: "DASHSCOPE_BASE_URL", label: "DashScope", placeholder: "https://dashscope.aliyuncs.com" },
@@ -31,19 +33,56 @@ const ENDPOINT_PROVIDERS = [
   { key: "VIDU_BASE_URL", label: "Vidu", placeholder: "https://api.vidu.cn/ent/v2" },
 ];
 
+const DEFAULT_CONFIG: EnvConfig = {
+  DASHSCOPE_API_KEY: "",
+  ALIBABA_CLOUD_ACCESS_KEY_ID: "",
+  ALIBABA_CLOUD_ACCESS_KEY_SECRET: "",
+  OSS_BUCKET_NAME: "",
+  OSS_ENDPOINT: "",
+  OSS_BASE_PATH: "",
+  KLING_PROVIDER_MODE: "dashscope",
+  VIDU_PROVIDER_MODE: "dashscope",
+  PIXVERSE_PROVIDER_MODE: "dashscope",
+  KLING_ACCESS_KEY: "",
+  KLING_SECRET_KEY: "",
+  VIDU_API_KEY: "",
+  endpoint_overrides: {},
+};
+
+const normalizeProviderMode = (mode?: string): ProviderMode => (mode === "vendor" ? "vendor" : "dashscope");
+
+const normalizeEnvConfig = (existing: EnvConfig, data?: EnvConfigPayload): EnvConfig => ({
+  ...existing,
+  ...data,
+  KLING_PROVIDER_MODE: normalizeProviderMode(data?.KLING_PROVIDER_MODE ?? existing.KLING_PROVIDER_MODE),
+  VIDU_PROVIDER_MODE: normalizeProviderMode(data?.VIDU_PROVIDER_MODE ?? existing.VIDU_PROVIDER_MODE),
+  PIXVERSE_PROVIDER_MODE: normalizeProviderMode(data?.PIXVERSE_PROVIDER_MODE ?? existing.PIXVERSE_PROVIDER_MODE),
+  endpoint_overrides: data?.endpoint_overrides ?? existing.endpoint_overrides ?? {},
+});
+
+const getValidationErrors = (env: EnvConfig): string[] => {
+  const errors: string[] = [];
+
+  if (!env.DASHSCOPE_API_KEY?.trim()) {
+    errors.push("DashScope API Key");
+  }
+  if (env.KLING_PROVIDER_MODE === "vendor") {
+    if (!env.KLING_ACCESS_KEY?.trim()) {
+      errors.push("Kling Access Key (vendor mode)");
+    }
+    if (!env.KLING_SECRET_KEY?.trim()) {
+      errors.push("Kling Secret Key (vendor mode)");
+    }
+  }
+  if (env.VIDU_PROVIDER_MODE === "vendor" && !env.VIDU_API_KEY?.trim()) {
+    errors.push("Vidu API Key (vendor mode)");
+  }
+
+  return errors;
+};
+
 export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }: EnvConfigDialogProps) {
-  const [config, setConfig] = useState<EnvConfig>({
-    DASHSCOPE_API_KEY: "",
-    ALIBABA_CLOUD_ACCESS_KEY_ID: "",
-    ALIBABA_CLOUD_ACCESS_KEY_SECRET: "",
-    OSS_BUCKET_NAME: "",
-    OSS_ENDPOINT: "",
-    OSS_BASE_PATH: "",
-    KLING_ACCESS_KEY: "",
-    KLING_SECRET_KEY: "",
-    VIDU_API_KEY: "",
-    endpoint_overrides: {},
-  });
+  const [config, setConfig] = useState<EnvConfig>(DEFAULT_CONFIG);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [endpointsOpen, setEndpointsOpen] = useState(false);
@@ -60,7 +99,7 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
     setLoadError(null);
     try {
       const data = await api.getEnvConfig();
-      setConfig({ ...config, ...data, endpoint_overrides: data.endpoint_overrides ?? {} });
+      setConfig((prev) => normalizeEnvConfig(prev, data));
     } catch (error) {
       console.error("Failed to load env config:", error);
       setLoadError("Failed to load configuration. Is the backend running?");
@@ -69,23 +108,13 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
     }
   };
 
-  const validateRequiredFields = () => {
-    const dashscopeKey = config.DASHSCOPE_API_KEY?.trim();
-    const accessKeyId = config.ALIBABA_CLOUD_ACCESS_KEY_ID?.trim();
-    const accessKeySecret = config.ALIBABA_CLOUD_ACCESS_KEY_SECRET?.trim();
-    const ossBucket = config.OSS_BUCKET_NAME?.trim();
-    const ossEndpoint = config.OSS_ENDPOINT?.trim();
-
-    return dashscopeKey && dashscopeKey.length > 0 &&
-      accessKeyId && accessKeyId.length > 0 &&
-      accessKeySecret && accessKeySecret.length > 0 &&
-      ossBucket && ossBucket.length > 0 &&
-      ossEndpoint && ossEndpoint.length > 0;
-  };
+  const validateRequiredFields = () => getValidationErrors(config).length === 0;
+  const canClose = !isRequired || validateRequiredFields();
 
   const handleSave = async () => {
-    if (!validateRequiredFields()) {
-      alert("Please fill in all required fields:\n- DashScope API Key\n- Alibaba Cloud Access Key ID\n- Alibaba Cloud Access Key Secret\n- OSS Bucket Name\n- OSS Endpoint");
+    const errors = getValidationErrors(config);
+    if (errors.length > 0) {
+      alert(`Please fill in required fields:\n- ${errors.join("\n- ")}`);
       return;
     }
 
@@ -116,9 +145,17 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
     }));
   };
 
+  const requestClose = () => {
+    if (canClose) {
+      onClose();
+    }
+  };
+
   if (!isOpen) return null;
 
   const inputClass = "w-full bg-black/30 border border-white/10 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-primary/50 transition-colors";
+  const modeButtonClass = (active: boolean) =>
+    `px-3 py-1.5 text-xs rounded-md border transition-colors ${active ? "border-amber-500/60 bg-amber-500/15 text-amber-200" : "border-white/10 bg-white/5 text-gray-400 hover:text-gray-200"}`;
 
   return (
     <AnimatePresence>
@@ -127,7 +164,7 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
-        onClick={onClose}
+        onClick={requestClose}
       >
         <motion.div
           initial={{ opacity: 0, scale: 0.95 }}
@@ -136,7 +173,6 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
           className="bg-[#1a1a1a] rounded-2xl border border-white/10 w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col"
           onClick={(e) => e.stopPropagation()}
         >
-          {/* Header */}
           <div className="flex items-center justify-between p-6 border-b border-white/10">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-gradient-to-br from-amber-500/20 to-orange-500/20 rounded-lg">
@@ -144,22 +180,27 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
               </div>
               <div>
                 <h2 className="text-lg font-bold text-white">Environment Configuration</h2>
-                <p className="text-xs text-gray-500">Configure API keys and cloud service credentials</p>
+                <p className="text-xs text-gray-500">DashScope-first setup, with optional OSS mirror and vendor-direct routing</p>
               </div>
             </div>
             <button
-              onClick={onClose}
-              className="p-2 hover:bg-white/10 rounded-lg transition-colors"
+              onClick={requestClose}
+              disabled={!canClose}
+              className="p-2 hover:bg-white/10 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
               <X size={20} className="text-gray-400" />
             </button>
           </div>
 
-          {/* Content */}
           <div className="flex-1 overflow-y-auto p-6 space-y-6">
             {isRequired && (
               <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3 text-xs text-yellow-300">
-                Missing required environment variables. Please fill in the required fields below to continue.
+                DashScope API Key is required before using the app. OSS and vendor keys are optional unless you select vendor-direct mode.
+              </div>
+            )}
+            {isRequired && !canClose && (
+              <div className="bg-white/5 border border-white/10 rounded-lg p-3 text-xs text-gray-400">
+                This dialog cannot be closed until required fields are valid.
               </div>
             )}
 
@@ -174,7 +215,6 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
               </div>
             ) : (
               <>
-                {/* DashScope API Key */}
                 <div>
                   <label className="flex items-center justify-between text-sm font-medium text-gray-300 mb-2">
                     <span>DashScope API Key <span className="text-red-500">*</span></span>
@@ -184,46 +224,48 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
                     type="password"
                     value={config.DASHSCOPE_API_KEY}
                     onChange={(e) => handleChange("DASHSCOPE_API_KEY", e.target.value)}
-                    placeholder="For Qwen and other DashScope models"
+                    placeholder="Required for DashScope-first model routing"
                     className={inputClass}
                   />
                 </div>
 
-                {/* Alibaba Cloud Access Keys */}
                 <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-4">
-                  <p className="text-xs text-gray-400">For OSS storage service</p>
-
+                  <div className="text-xs text-gray-400">
+                    Storage is local-first by default. OSS credentials are optional and only used as a cloud mirror.
+                  </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-300 mb-2">
-                      Alibaba Cloud Access Key ID <span className="text-red-500">*</span>
+                      Alibaba Cloud Access Key ID
                     </label>
                     <input
                       type="password"
                       value={config.ALIBABA_CLOUD_ACCESS_KEY_ID}
                       onChange={(e) => handleChange("ALIBABA_CLOUD_ACCESS_KEY_ID", e.target.value)}
-                      placeholder="LTAI5t..."
+                      placeholder="Optional, used when OSS mirror is enabled"
                       className={inputClass}
                     />
                   </div>
 
                   <div>
                     <label className="block text-sm font-medium text-gray-300 mb-2">
-                      Alibaba Cloud Access Key Secret <span className="text-red-500">*</span>
+                      Alibaba Cloud Access Key Secret
                     </label>
                     <input
                       type="password"
                       value={config.ALIBABA_CLOUD_ACCESS_KEY_SECRET}
                       onChange={(e) => handleChange("ALIBABA_CLOUD_ACCESS_KEY_SECRET", e.target.value)}
-                      placeholder="Access key secret"
+                      placeholder="Optional, used when OSS mirror is enabled"
                       className={inputClass}
                     />
                   </div>
                 </div>
 
-                {/* OSS Configuration */}
                 <div className="pt-4 border-t border-white/10">
                   <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-sm font-bold text-white">OSS Configuration</h3>
+                    <div>
+                      <h3 className="text-sm font-bold text-white">OSS Mirror (Optional)</h3>
+                      <p className="text-[10px] text-gray-500 mt-1">When configured, generated media is stored locally and mirrored to OSS.</p>
+                    </div>
                     <a
                       href="https://oss.console.aliyun.com/overview"
                       target="_blank"
@@ -237,28 +279,28 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
                   <div className="space-y-4">
                     <div>
                       <label className="flex items-center justify-between text-sm font-medium text-gray-300 mb-2">
-                        <span>OSS Bucket Name <span className="text-red-500">*</span></span>
+                        <span>OSS Bucket Name</span>
                         <span className="text-gray-600 font-normal text-xs">e.g. my-comic-bucket</span>
                       </label>
                       <input
                         type="text"
                         value={config.OSS_BUCKET_NAME}
                         onChange={(e) => handleChange("OSS_BUCKET_NAME", e.target.value)}
-                        placeholder="your_bucket_name"
+                        placeholder="your_bucket_name (optional)"
                         className={inputClass}
                       />
                     </div>
 
                     <div>
                       <label className="flex items-center justify-between text-sm font-medium text-gray-300 mb-2">
-                        <span>OSS Endpoint <span className="text-red-500">*</span></span>
+                        <span>OSS Endpoint</span>
                         <span className="text-gray-600 font-normal text-xs">e.g. oss-cn-hangzhou.aliyuncs.com</span>
                       </label>
                       <input
                         type="text"
                         value={config.OSS_ENDPOINT}
                         onChange={(e) => handleChange("OSS_ENDPOINT", e.target.value)}
-                        placeholder="oss-cn-beijing.aliyuncs.com"
+                        placeholder="oss-cn-beijing.aliyuncs.com (optional)"
                         className={inputClass}
                       />
                     </div>
@@ -279,64 +321,107 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
                   </div>
                 </div>
 
-                {/* Kling Configuration */}
                 <div className="pt-4 border-t border-white/10">
                   <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-sm font-bold text-white">Kling AI</h3>
-                    <span className="text-[10px] text-gray-500">Optional &mdash; for Kling video generation</span>
+                    <h3 className="text-sm font-bold text-white">Kling Provider</h3>
+                    <span className="text-[10px] text-gray-500">Choose DashScope proxy or vendor-direct</span>
                   </div>
-
                   <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-4">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-300 mb-2">
-                        Kling Access Key
-                      </label>
-                      <input
-                        type="password"
-                        value={config.KLING_ACCESS_KEY}
-                        onChange={(e) => handleChange("KLING_ACCESS_KEY", e.target.value)}
-                        placeholder="Kling API Access Key"
-                        className={inputClass}
-                      />
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleChange("KLING_PROVIDER_MODE", "dashscope")}
+                        className={modeButtonClass(config.KLING_PROVIDER_MODE === "dashscope")}
+                      >
+                        DashScope
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleChange("KLING_PROVIDER_MODE", "vendor")}
+                        className={modeButtonClass(config.KLING_PROVIDER_MODE === "vendor")}
+                      >
+                        Vendor Direct
+                      </button>
                     </div>
+                    <p className="text-xs text-gray-500">
+                      DashScope mode uses your DashScope API key. Vendor-direct mode requires Kling Access Key and Secret Key.
+                    </p>
 
-                    <div>
-                      <label className="block text-sm font-medium text-gray-300 mb-2">
-                        Kling Secret Key
-                      </label>
-                      <input
-                        type="password"
-                        value={config.KLING_SECRET_KEY}
-                        onChange={(e) => handleChange("KLING_SECRET_KEY", e.target.value)}
-                        placeholder="Kling API Secret Key"
-                        className={inputClass}
-                      />
-                    </div>
+                    {config.KLING_PROVIDER_MODE === "vendor" && (
+                      <>
+                        <div>
+                          <label className="block text-sm font-medium text-gray-300 mb-2">
+                            Kling Access Key <span className="text-red-500">*</span>
+                          </label>
+                          <input
+                            type="password"
+                            value={config.KLING_ACCESS_KEY}
+                            onChange={(e) => handleChange("KLING_ACCESS_KEY", e.target.value)}
+                            placeholder="Kling API Access Key"
+                            className={inputClass}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-300 mb-2">
+                            Kling Secret Key <span className="text-red-500">*</span>
+                          </label>
+                          <input
+                            type="password"
+                            value={config.KLING_SECRET_KEY}
+                            onChange={(e) => handleChange("KLING_SECRET_KEY", e.target.value)}
+                            placeholder="Kling API Secret Key"
+                            className={inputClass}
+                          />
+                        </div>
+                      </>
+                    )}
                   </div>
                 </div>
 
-                {/* Vidu Configuration */}
                 <div className="pt-4 border-t border-white/10">
                   <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-sm font-bold text-white">Vidu AI</h3>
-                    <span className="text-[10px] text-gray-500">Optional &mdash; for Vidu video generation</span>
+                    <h3 className="text-sm font-bold text-white">Vidu Provider</h3>
+                    <span className="text-[10px] text-gray-500">Choose DashScope proxy or vendor-direct</span>
                   </div>
+                  <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-4">
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleChange("VIDU_PROVIDER_MODE", "dashscope")}
+                        className={modeButtonClass(config.VIDU_PROVIDER_MODE === "dashscope")}
+                      >
+                        DashScope
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleChange("VIDU_PROVIDER_MODE", "vendor")}
+                        className={modeButtonClass(config.VIDU_PROVIDER_MODE === "vendor")}
+                      >
+                        Vendor Direct
+                      </button>
+                    </div>
+                    <p className="text-xs text-gray-500">
+                      DashScope mode uses your DashScope API key. Vendor-direct mode requires a Vidu API key.
+                    </p>
 
-                  <div>
-                    <label className="block text-sm font-medium text-gray-300 mb-2">
-                      Vidu API Key
-                    </label>
-                    <input
-                      type="password"
-                      value={config.VIDU_API_KEY}
-                      onChange={(e) => handleChange("VIDU_API_KEY", e.target.value)}
-                      placeholder="Vidu API Key"
-                      className={inputClass}
-                    />
+                    {config.VIDU_PROVIDER_MODE === "vendor" && (
+                      <div>
+                        <label className="block text-sm font-medium text-gray-300 mb-2">
+                          Vidu API Key <span className="text-red-500">*</span>
+                        </label>
+                        <input
+                          type="password"
+                          value={config.VIDU_API_KEY}
+                          onChange={(e) => handleChange("VIDU_API_KEY", e.target.value)}
+                          placeholder="Vidu API Key"
+                          className={inputClass}
+                        />
+                      </div>
+                    )}
                   </div>
                 </div>
 
-                {/* Advanced: API Endpoints */}
                 <div className="pt-4 border-t border-white/10">
                   <button
                     type="button"
@@ -351,7 +436,7 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
                   {endpointsOpen && (
                     <div className="mt-4 space-y-4">
                       <p className="text-xs text-gray-500">
-                        Custom API endpoint URLs. Leave empty to use defaults. Switch to international endpoints for overseas deployment.
+                        Custom API endpoint URLs. Leave empty to use defaults. Endpoint overrides are preserved regardless of provider mode.
                       </p>
                       {ENDPOINT_PROVIDERS.map(({ key, label, placeholder }) => (
                         <div key={key}>
@@ -375,11 +460,11 @@ export default function EnvConfigDialog({ isOpen, onClose, isRequired = false }:
             )}
           </div>
 
-          {/* Footer */}
           <div className="flex justify-end gap-3 p-6 border-t border-white/10">
             <button
-              onClick={onClose}
-              className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+              onClick={requestClose}
+              disabled={!canClose}
+              className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Cancel
             </button>

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -2,29 +2,79 @@
 
 import { useState, useEffect } from "react";
 import { Save, Loader2, Key, ChevronDown, ChevronRight, Settings, MessageSquareCode } from "lucide-react";
-import { api } from "@/lib/api";
+import { api, type EnvConfigPayload, type ProviderMode } from "@/lib/api";
 import { T2I_MODELS, I2I_MODELS, I2V_MODELS, ASPECT_RATIOS } from "@/store/projectStore";
 import { Image, Video, Layout, Check, User, Building, Box } from "lucide-react";
 
-interface EnvConfig {
+type EnvConfig = EnvConfigPayload & {
   DASHSCOPE_API_KEY: string;
   ALIBABA_CLOUD_ACCESS_KEY_ID: string;
   ALIBABA_CLOUD_ACCESS_KEY_SECRET: string;
   OSS_BUCKET_NAME: string;
   OSS_ENDPOINT: string;
   OSS_BASE_PATH: string;
+  KLING_PROVIDER_MODE: ProviderMode;
+  VIDU_PROVIDER_MODE: ProviderMode;
+  PIXVERSE_PROVIDER_MODE: ProviderMode;
   KLING_ACCESS_KEY: string;
   KLING_SECRET_KEY: string;
   VIDU_API_KEY: string;
   endpoint_overrides: Record<string, string>;
-  [key: string]: string | Record<string, string>;
-}
+};
 
 const ENDPOINT_PROVIDERS = [
   { key: "DASHSCOPE_BASE_URL", label: "DashScope", placeholder: "https://dashscope.aliyuncs.com" },
   { key: "KLING_BASE_URL", label: "Kling", placeholder: "https://api-beijing.klingai.com/v1" },
   { key: "VIDU_BASE_URL", label: "Vidu", placeholder: "https://api.vidu.cn/ent/v2" },
 ];
+
+const DEFAULT_CONFIG: EnvConfig = {
+  DASHSCOPE_API_KEY: "",
+  ALIBABA_CLOUD_ACCESS_KEY_ID: "",
+  ALIBABA_CLOUD_ACCESS_KEY_SECRET: "",
+  OSS_BUCKET_NAME: "",
+  OSS_ENDPOINT: "",
+  OSS_BASE_PATH: "",
+  KLING_PROVIDER_MODE: "dashscope",
+  VIDU_PROVIDER_MODE: "dashscope",
+  PIXVERSE_PROVIDER_MODE: "dashscope",
+  KLING_ACCESS_KEY: "",
+  KLING_SECRET_KEY: "",
+  VIDU_API_KEY: "",
+  endpoint_overrides: {},
+};
+
+const normalizeProviderMode = (mode?: string): ProviderMode => (mode === "vendor" ? "vendor" : "dashscope");
+
+const normalizeEnvConfig = (existing: EnvConfig, data?: EnvConfigPayload): EnvConfig => ({
+  ...existing,
+  ...data,
+  KLING_PROVIDER_MODE: normalizeProviderMode(data?.KLING_PROVIDER_MODE ?? existing.KLING_PROVIDER_MODE),
+  VIDU_PROVIDER_MODE: normalizeProviderMode(data?.VIDU_PROVIDER_MODE ?? existing.VIDU_PROVIDER_MODE),
+  PIXVERSE_PROVIDER_MODE: normalizeProviderMode(data?.PIXVERSE_PROVIDER_MODE ?? existing.PIXVERSE_PROVIDER_MODE),
+  endpoint_overrides: data?.endpoint_overrides ?? existing.endpoint_overrides ?? {},
+});
+
+const getValidationErrors = (env: EnvConfig): string[] => {
+  const errors: string[] = [];
+
+  if (!env.DASHSCOPE_API_KEY?.trim()) {
+    errors.push("DashScope API Key");
+  }
+  if (env.KLING_PROVIDER_MODE === "vendor") {
+    if (!env.KLING_ACCESS_KEY?.trim()) {
+      errors.push("Kling Access Key (vendor mode)");
+    }
+    if (!env.KLING_SECRET_KEY?.trim()) {
+      errors.push("Kling Secret Key (vendor mode)");
+    }
+  }
+  if (env.VIDU_PROVIDER_MODE === "vendor" && !env.VIDU_API_KEY?.trim()) {
+    errors.push("Vidu API Key (vendor mode)");
+  }
+
+  return errors;
+};
 
 const LS_KEY_MODEL = "lumenx_default_model_settings";
 const LS_KEY_PROMPT = "lumenx_default_prompt_config";
@@ -57,18 +107,7 @@ function loadFromLS<T>(key: string, fallback: T): T {
 
 export default function SettingsPage() {
   // ── API Config ──
-  const [config, setConfig] = useState<EnvConfig>({
-    DASHSCOPE_API_KEY: "",
-    ALIBABA_CLOUD_ACCESS_KEY_ID: "",
-    ALIBABA_CLOUD_ACCESS_KEY_SECRET: "",
-    OSS_BUCKET_NAME: "",
-    OSS_ENDPOINT: "",
-    OSS_BASE_PATH: "",
-    KLING_ACCESS_KEY: "",
-    KLING_SECRET_KEY: "",
-    VIDU_API_KEY: "",
-    endpoint_overrides: {},
-  });
+  const [config, setConfig] = useState<EnvConfig>(DEFAULT_CONFIG);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -101,7 +140,7 @@ export default function SettingsPage() {
     setLoadError(null);
     try {
       const data = await api.getEnvConfig();
-      setConfig((prev) => ({ ...prev, ...data, endpoint_overrides: data.endpoint_overrides ?? {} }));
+      setConfig((prev) => normalizeEnvConfig(prev, data));
     } catch {
       setLoadError("Failed to load configuration. Is the backend running?");
     } finally {
@@ -110,6 +149,12 @@ export default function SettingsPage() {
   };
 
   const handleSaveApiConfig = async () => {
+    const errors = getValidationErrors(config);
+    if (errors.length > 0) {
+      alert(`Please fill in required fields:\n- ${errors.join("\n- ")}`);
+      return;
+    }
+
     setSaving(true);
     try {
       await api.saveEnvConfig(config);
@@ -144,6 +189,8 @@ export default function SettingsPage() {
 
   const inputClass =
     "w-full bg-black/30 border border-white/10 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-primary/50 transition-colors";
+  const modeButtonClass = (active: boolean) =>
+    `px-3 py-1.5 text-xs rounded-md border transition-colors ${active ? "border-amber-500/60 bg-amber-500/15 text-amber-200" : "border-white/10 bg-white/5 text-gray-400 hover:text-gray-200"}`;
 
   return (
     <div className="container mx-auto px-6 py-8 max-w-4xl space-y-8">
@@ -157,7 +204,7 @@ export default function SettingsPage() {
           </div>
           <div>
             <h2 className="text-lg font-bold text-white">API 配置</h2>
-            <p className="text-xs text-gray-500">Configure API keys and cloud service credentials</p>
+            <p className="text-xs text-gray-500">DashScope-first setup with optional OSS mirror and provider-direct routing</p>
           </div>
         </div>
 
@@ -177,35 +224,36 @@ export default function SettingsPage() {
                 <span>DashScope API Key <span className="text-red-500">*</span></span>
                 <span className="text-gray-600 font-normal text-xs">e.g. sk-xxx</span>
               </label>
-              <input type="password" value={config.DASHSCOPE_API_KEY} onChange={(e) => handleChange("DASHSCOPE_API_KEY", e.target.value)} placeholder="For Qwen and other DashScope models" className={inputClass} />
+              <input type="password" value={config.DASHSCOPE_API_KEY} onChange={(e) => handleChange("DASHSCOPE_API_KEY", e.target.value)} placeholder="Required for DashScope-first model routing" className={inputClass} />
             </div>
 
             <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-4">
-              <p className="text-xs text-gray-400">For OSS storage service</p>
+              <p className="text-xs text-gray-400">Storage is local-first by default. These credentials are only needed when enabling OSS mirror.</p>
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-2">Alibaba Cloud Access Key ID <span className="text-red-500">*</span></label>
-                <input type="password" value={config.ALIBABA_CLOUD_ACCESS_KEY_ID} onChange={(e) => handleChange("ALIBABA_CLOUD_ACCESS_KEY_ID", e.target.value)} placeholder="LTAI5t..." className={inputClass} />
+                <label className="block text-sm font-medium text-gray-300 mb-2">Alibaba Cloud Access Key ID</label>
+                <input type="password" value={config.ALIBABA_CLOUD_ACCESS_KEY_ID} onChange={(e) => handleChange("ALIBABA_CLOUD_ACCESS_KEY_ID", e.target.value)} placeholder="Optional, for OSS mirror" className={inputClass} />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-2">Alibaba Cloud Access Key Secret <span className="text-red-500">*</span></label>
-                <input type="password" value={config.ALIBABA_CLOUD_ACCESS_KEY_SECRET} onChange={(e) => handleChange("ALIBABA_CLOUD_ACCESS_KEY_SECRET", e.target.value)} placeholder="Access key secret" className={inputClass} />
+                <label className="block text-sm font-medium text-gray-300 mb-2">Alibaba Cloud Access Key Secret</label>
+                <input type="password" value={config.ALIBABA_CLOUD_ACCESS_KEY_SECRET} onChange={(e) => handleChange("ALIBABA_CLOUD_ACCESS_KEY_SECRET", e.target.value)} placeholder="Optional, for OSS mirror" className={inputClass} />
               </div>
             </div>
 
             <div className="pt-4 border-t border-white/10">
-              <h3 className="text-sm font-bold text-white mb-4">OSS Configuration</h3>
+              <h3 className="text-sm font-bold text-white mb-2">OSS Mirror (Optional)</h3>
+              <p className="text-[10px] text-gray-500 mb-4">Generated assets always save locally first. Configure OSS to keep an optional cloud mirror.</p>
               <div className="space-y-4">
                 <div>
                   <label className="flex items-center justify-between text-sm font-medium text-gray-300 mb-2">
-                    <span>OSS Bucket Name <span className="text-red-500">*</span></span>
+                    <span>OSS Bucket Name</span>
                   </label>
-                  <input type="text" value={config.OSS_BUCKET_NAME} onChange={(e) => handleChange("OSS_BUCKET_NAME", e.target.value)} placeholder="your_bucket_name" className={inputClass} />
+                  <input type="text" value={config.OSS_BUCKET_NAME} onChange={(e) => handleChange("OSS_BUCKET_NAME", e.target.value)} placeholder="your_bucket_name (optional)" className={inputClass} />
                 </div>
                 <div>
                   <label className="flex items-center justify-between text-sm font-medium text-gray-300 mb-2">
-                    <span>OSS Endpoint <span className="text-red-500">*</span></span>
+                    <span>OSS Endpoint</span>
                   </label>
-                  <input type="text" value={config.OSS_ENDPOINT} onChange={(e) => handleChange("OSS_ENDPOINT", e.target.value)} placeholder="oss-cn-beijing.aliyuncs.com" className={inputClass} />
+                  <input type="text" value={config.OSS_ENDPOINT} onChange={(e) => handleChange("OSS_ENDPOINT", e.target.value)} placeholder="oss-cn-beijing.aliyuncs.com (optional)" className={inputClass} />
                 </div>
                 <div>
                   <label className="block text-sm font-medium text-gray-300 mb-2">OSS Base Path</label>
@@ -215,24 +263,54 @@ export default function SettingsPage() {
             </div>
 
             <div className="pt-4 border-t border-white/10">
-              <h3 className="text-sm font-bold text-white mb-4">Kling AI</h3>
+              <h3 className="text-sm font-bold text-white mb-4">Kling Provider</h3>
               <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-2">Kling Access Key</label>
-                  <input type="password" value={config.KLING_ACCESS_KEY} onChange={(e) => handleChange("KLING_ACCESS_KEY", e.target.value)} placeholder="Kling API Access Key" className={inputClass} />
+                <div className="flex flex-wrap gap-2">
+                  <button type="button" onClick={() => handleChange("KLING_PROVIDER_MODE", "dashscope")} className={modeButtonClass(config.KLING_PROVIDER_MODE === "dashscope")}>
+                    DashScope
+                  </button>
+                  <button type="button" onClick={() => handleChange("KLING_PROVIDER_MODE", "vendor")} className={modeButtonClass(config.KLING_PROVIDER_MODE === "vendor")}>
+                    Vendor Direct
+                  </button>
                 </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-2">Kling Secret Key</label>
-                  <input type="password" value={config.KLING_SECRET_KEY} onChange={(e) => handleChange("KLING_SECRET_KEY", e.target.value)} placeholder="Kling API Secret Key" className={inputClass} />
-                </div>
+                <p className="text-xs text-gray-500">
+                  DashScope mode uses your DashScope API key. Vendor-direct mode requires Kling Access Key and Secret Key.
+                </p>
+                {config.KLING_PROVIDER_MODE === "vendor" && (
+                  <>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-300 mb-2">Kling Access Key <span className="text-red-500">*</span></label>
+                      <input type="password" value={config.KLING_ACCESS_KEY} onChange={(e) => handleChange("KLING_ACCESS_KEY", e.target.value)} placeholder="Kling API Access Key" className={inputClass} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-300 mb-2">Kling Secret Key <span className="text-red-500">*</span></label>
+                      <input type="password" value={config.KLING_SECRET_KEY} onChange={(e) => handleChange("KLING_SECRET_KEY", e.target.value)} placeholder="Kling API Secret Key" className={inputClass} />
+                    </div>
+                  </>
+                )}
               </div>
             </div>
 
             <div className="pt-4 border-t border-white/10">
-              <h3 className="text-sm font-bold text-white mb-4">Vidu AI</h3>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-2">Vidu API Key</label>
-                <input type="password" value={config.VIDU_API_KEY} onChange={(e) => handleChange("VIDU_API_KEY", e.target.value)} placeholder="Vidu API Key" className={inputClass} />
+              <h3 className="text-sm font-bold text-white mb-4">Vidu Provider</h3>
+              <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-4">
+                <div className="flex flex-wrap gap-2">
+                  <button type="button" onClick={() => handleChange("VIDU_PROVIDER_MODE", "dashscope")} className={modeButtonClass(config.VIDU_PROVIDER_MODE === "dashscope")}>
+                    DashScope
+                  </button>
+                  <button type="button" onClick={() => handleChange("VIDU_PROVIDER_MODE", "vendor")} className={modeButtonClass(config.VIDU_PROVIDER_MODE === "vendor")}>
+                    Vendor Direct
+                  </button>
+                </div>
+                <p className="text-xs text-gray-500">
+                  DashScope mode uses your DashScope API key. Vendor-direct mode requires a Vidu API key.
+                </p>
+                {config.VIDU_PROVIDER_MODE === "vendor" && (
+                  <div>
+                    <label className="block text-sm font-medium text-gray-300 mb-2">Vidu API Key <span className="text-red-500">*</span></label>
+                    <input type="password" value={config.VIDU_API_KEY} onChange={(e) => handleChange("VIDU_API_KEY", e.target.value)} placeholder="Vidu API Key" className={inputClass} />
+                  </div>
+                )}
               </div>
             </div>
 
@@ -243,7 +321,7 @@ export default function SettingsPage() {
               </button>
               {endpointsOpen && (
                 <div className="mt-4 space-y-4">
-                  <p className="text-xs text-gray-500">Custom API endpoint URLs. Leave empty to use defaults.</p>
+                  <p className="text-xs text-gray-500">Custom API endpoint URLs. Leave empty to use defaults. Overrides are preserved regardless of provider mode.</p>
                   {ENDPOINT_PROVIDERS.map(({ key, label, placeholder }) => (
                     <div key={key}>
                       <label className="flex items-center justify-between text-sm font-medium text-gray-300 mb-2">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -25,6 +25,25 @@ const getApiUrl = (): string => {
 
 export const API_URL = getApiUrl();
 
+export type ProviderMode = "dashscope" | "vendor";
+
+export interface EnvConfigPayload {
+    DASHSCOPE_API_KEY?: string;
+    ALIBABA_CLOUD_ACCESS_KEY_ID?: string;
+    ALIBABA_CLOUD_ACCESS_KEY_SECRET?: string;
+    OSS_BUCKET_NAME?: string;
+    OSS_ENDPOINT?: string;
+    OSS_BASE_PATH?: string;
+    KLING_PROVIDER_MODE?: ProviderMode;
+    VIDU_PROVIDER_MODE?: ProviderMode;
+    PIXVERSE_PROVIDER_MODE?: ProviderMode;
+    KLING_ACCESS_KEY?: string;
+    KLING_SECRET_KEY?: string;
+    VIDU_API_KEY?: string;
+    endpoint_overrides?: Record<string, string>;
+    [key: string]: string | Record<string, string> | undefined;
+}
+
 export interface VideoTask {
     id: string;
     project_id: string;
@@ -523,12 +542,12 @@ export const api = {
         return res.data;
     },
 
-    getEnvConfig: async () => {
-        const res = await axios.get(`${API_URL}/config/env`);
+    getEnvConfig: async (): Promise<EnvConfigPayload> => {
+        const res = await axios.get<EnvConfigPayload>(`${API_URL}/config/env`);
         return res.data;
     },
 
-    saveEnvConfig: async (config: Record<string, string | Record<string, string> | undefined>) => {
+    saveEnvConfig: async (config: EnvConfigPayload) => {
         const res = await axios.post(`${API_URL}/config/env`, config, {
             timeout: 60000, // 60 seconds timeout
         });

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -6,9 +6,8 @@ export default defineConfig({
         jsx: 'automatic',
     },
     test: {
-        environment: 'jsdom',
+        environment: 'node',
         include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/*.test.tsx', 'src/**/*.spec.tsx'],
-        setupFiles: ['./vitest.setup.ts'],
     },
     resolve: {
         alias: {

--- a/frontend/vitest.ui.config.mts
+++ b/frontend/vitest.ui.config.mts
@@ -6,12 +6,10 @@ export default defineConfig({
         jsx: 'automatic',
     },
     test: {
-        environment: 'node',
+        environment: 'happy-dom',
         include: [
-            'src/__tests__/**/*.test.ts',
-            'src/__tests__/**/*.spec.ts',
-            'src/__tests__/**/*.test.tsx',
-            'src/__tests__/**/*.spec.tsx',
+            'src/components/**/*.test.tsx',
+            'src/components/**/*.spec.tsx',
         ],
         setupFiles: ['./vitest.setup.ts'],
     },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -441,7 +441,7 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^20", "@types/node@^20.19.0 || >=22.12.0":
+"@types/node@*", "@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^20", "@types/node@^20.19.0 || >=22.12.0", "@types/node@>=20.0.0":
   version "20.19.25"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz"
   integrity sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==
@@ -505,6 +505,18 @@
   version "0.5.24"
   resolved "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz"
   integrity sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==
+
+"@types/whatwg-mimetype@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.anpm.alibaba-inc.com/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz"
+  integrity sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==
+
+"@types/ws@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.anpm.alibaba-inc.com/@types/ws/-/ws-8.18.1.tgz"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version "8.48.0"
@@ -1336,6 +1348,11 @@ entities@^6.0.0:
   resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz"
   integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.anpm.alibaba-inc.com/entities/-/entities-7.0.1.tgz"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+
 es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9, es-abstract@^1.24.0:
   version "1.24.0"
   resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz"
@@ -2009,6 +2026,18 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+happy-dom@*, happy-dom@^20.8.9:
+  version "20.8.9"
+  resolved "https://registry.anpm.alibaba-inc.com/happy-dom/-/happy-dom-20.8.9.tgz"
+  integrity sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==
+  dependencies:
+    "@types/node" ">=20.0.0"
+    "@types/whatwg-mimetype" "^3.0.2"
+    "@types/ws" "^8.18.1"
+    entities "^7.0.1"
+    whatwg-mimetype "^3.0.0"
+    ws "^8.18.3"
 
 has-bigints@^1.0.2:
   version "1.1.0"
@@ -4056,6 +4085,11 @@ whatwg-encoding@^3.1.1:
   integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
   dependencies:
     iconv-lite "0.6.3"
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.anpm.alibaba-inc.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
 whatwg-mimetype@^4.0.0:
   version "4.0.0"

--- a/src/apps/comic_gen/api.py
+++ b/src/apps/comic_gen/api.py
@@ -13,7 +13,14 @@ import uuid
 import logging
 import traceback
 from .pipeline import ComicGenPipeline
-from .models import Script, VideoTask, PromptConfig, Series
+from .models import (
+    PromptConfig,
+    ProviderBackend,
+    ProviderRoutingConfig,
+    Script,
+    Series,
+    VideoTask,
+)
 from .llm import ScriptProcessor, DEFAULT_STORYBOARD_POLISH_PROMPT, DEFAULT_VIDEO_POLISH_PROMPT, DEFAULT_R2V_POLISH_PROMPT
 from ...utils.oss_utils import OSSImageUploader, sign_oss_urls_in_data
 from ...utils import setup_logging
@@ -641,7 +648,7 @@ async def import_file_confirm(request: ConfirmImportRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-class EnvConfig(BaseModel):
+class EnvConfig(ProviderRoutingConfig):
     DASHSCOPE_API_KEY: Optional[str] = None
     ALIBABA_CLOUD_ACCESS_KEY_ID: Optional[str] = None
     ALIBABA_CLOUD_ACCESS_KEY_SECRET: Optional[str] = None
@@ -651,7 +658,14 @@ class EnvConfig(BaseModel):
     KLING_ACCESS_KEY: Optional[str] = None
     KLING_SECRET_KEY: Optional[str] = None
     VIDU_API_KEY: Optional[str] = None
-    endpoint_overrides: Dict[str, str] = {}
+    endpoint_overrides: Dict[str, str] = Field(default_factory=dict)
+
+
+def _normalize_provider_mode(value: Optional[str]) -> str:
+    normalized = (value or "").strip().lower()
+    if normalized in (ProviderBackend.DASHSCOPE.value, ProviderBackend.VENDOR.value):
+        return normalized
+    return ProviderBackend.DASHSCOPE.value
 
 
 def get_user_config_path() -> str:
@@ -770,13 +784,20 @@ async def get_config_info():
 async def update_env_config(config: EnvConfig):
     """Updates environment configuration and saves to config file."""
     try:
-        config_dict = config.dict(exclude_unset=True)
+        raw_config = config.dict(exclude_unset=True)
 
         # Extract endpoint_overrides and flatten into config_dict
-        endpoint_overrides = config_dict.pop("endpoint_overrides", {})
+        endpoint_overrides = raw_config.pop("endpoint_overrides", {})
 
-        # Filter out None values
-        config_dict = {k: v for k, v in config_dict.items() if v is not None}
+        # Filter out None values and serialize enum values as plain strings.
+        config_dict: Dict[str, str] = {}
+        for key, value in raw_config.items():
+            if value is None:
+                continue
+            if isinstance(value, ProviderBackend):
+                config_dict[key] = value.value
+            else:
+                config_dict[key] = value
 
         # Process endpoint overrides: validate keys against known providers
         from ...utils.endpoints import PROVIDER_DEFAULTS
@@ -2000,6 +2021,9 @@ async def get_env_config():
             "KLING_ACCESS_KEY": os.getenv("KLING_ACCESS_KEY", ""),
             "KLING_SECRET_KEY": os.getenv("KLING_SECRET_KEY", ""),
             "VIDU_API_KEY": os.getenv("VIDU_API_KEY", ""),
+            "KLING_PROVIDER_MODE": _normalize_provider_mode(os.getenv("KLING_PROVIDER_MODE")),
+            "VIDU_PROVIDER_MODE": _normalize_provider_mode(os.getenv("VIDU_PROVIDER_MODE")),
+            "PIXVERSE_PROVIDER_MODE": _normalize_provider_mode(os.getenv("PIXVERSE_PROVIDER_MODE")),
             "endpoint_overrides": endpoint_overrides,
         }
     except Exception as e:
@@ -2063,4 +2087,3 @@ async def delete_prop(script_id: str, prop_id: str):
     pipeline._save_data()
 
     return signed_response(script)
-

--- a/src/apps/comic_gen/models.py
+++ b/src/apps/comic_gen/models.py
@@ -15,6 +15,26 @@ class GenerationStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
 
+
+class ProviderBackend(str, Enum):
+    DASHSCOPE = "dashscope"
+    VENDOR = "vendor"
+
+
+class ProviderRoutingConfig(BaseModel):
+    KLING_PROVIDER_MODE: ProviderBackend = Field(
+        ProviderBackend.DASHSCOPE,
+        description="Provider backend for kling-* models: dashscope or vendor",
+    )
+    VIDU_PROVIDER_MODE: ProviderBackend = Field(
+        ProviderBackend.DASHSCOPE,
+        description="Provider backend for vidu* models: dashscope or vendor",
+    )
+    PIXVERSE_PROVIDER_MODE: ProviderBackend = Field(
+        ProviderBackend.DASHSCOPE,
+        description="Provider backend for pixverse-* models: dashscope or vendor",
+    )
+
 class ImageVariant(BaseModel):
     id: str = Field(..., description="Unique identifier for the variant")
     url: str = Field(..., description="URL of the image")

--- a/src/apps/comic_gen/pipeline.py
+++ b/src/apps/comic_gen/pipeline.py
@@ -17,6 +17,7 @@ from .audio import AudioGenerator
 from .export import ExportManager
 from ...utils import get_logger
 from ...utils.oss_utils import is_object_key
+from ...utils.provider_registry import resolve_provider_backend
 from ...utils.system_check import get_ffmpeg_path, get_ffmpeg_install_instructions
 
 logger = get_logger(__name__)
@@ -71,6 +72,24 @@ class ComicGenPipeline:
         # Cached model instances for Kling/Vidu (lazily initialized)
         self._kling_model = None
         self._vidu_model = None
+
+    def _resolve_video_backend(self, model_name: str) -> str:
+        try:
+            return resolve_provider_backend(model_name)
+        except (KeyError, ValueError):
+            logger.debug(
+                "Provider backend not registered for video model %s, defaulting to dashscope.",
+                model_name,
+            )
+            return "dashscope"
+        except Exception as e:
+            logger.warning(
+                "Unexpected error resolving provider backend for video model %s: %s. "
+                "Falling back to dashscope.",
+                model_name,
+                e,
+            )
+            return "dashscope"
 
     # ... (existing methods)
 
@@ -1990,9 +2009,17 @@ class ComicGenPipeline:
             img_url = task.image_url
 
             # Route to the appropriate model based on task.model
-            model_prefix = (task.model or "").split("-")[0] if task.model else ""
+            model_name = task.model or ""
+            model_name_lower = model_name.lower()
+            backend = self._resolve_video_backend(model_name)
+            use_vendor_kling = backend == "vendor" and model_name_lower.startswith("kling-")
+            use_vendor_vidu = backend == "vendor" and (
+                model_name_lower.startswith("vidu")
+                or model_name_lower.startswith("viduq2")
+                or model_name_lower.startswith("viduq3")
+            )
 
-            if model_prefix in ("kling",):
+            if use_vendor_kling:
                 # Use Kling model (cached)
                 if self._kling_model is None:
                     from ...models.kling import KlingModel
@@ -2010,7 +2037,7 @@ class ComicGenPipeline:
                     sound=task.sound or "off",
                     cfg_scale=task.cfg_scale,
                 )
-            elif model_prefix in ("vidu", "viduq2", "viduq3"):
+            elif use_vendor_vidu:
                 # Use Vidu model (cached)
                 if self._vidu_model is None:
                     from ...models.vidu import ViduModel

--- a/src/models/image.py
+++ b/src/models/image.py
@@ -11,6 +11,8 @@ from dashscope import ImageSynthesis
 from ..utils import get_logger
 from ..utils.endpoints import get_provider_base_url
 from ..utils.oss_utils import OSSImageUploader
+from ..utils.provider_media import resolve_media_input
+from ..utils.provider_registry import resolve_provider_backend
 
 logger = get_logger(__name__)
 
@@ -333,37 +335,41 @@ class WanxImageModel(ImageGenModel):
         
         raise RuntimeError(f"Wan 2.6 Image task timed out after {max_wait_time}s")
 
-    def _resolve_wan26_reference_image(self, path: str) -> str:
-        if os.path.exists(path):
-            uploader = OSSImageUploader()
-            if uploader.is_configured:
-                object_key = uploader.upload_file(path, sub_path="temp/ref_images")
-                if object_key:
-                    signed_url = uploader.sign_url_for_api(object_key)
-                    logger.info(f"Reference image uploaded, signed URL: {signed_url[:80]}...")
-                    return signed_url
+    def _resolve_wan26_reference_image(self, path: str, model_name: str = "wan2.6-image") -> str:
+        uploader = OSSImageUploader()
+        backend = self._resolve_provider_backend_for_model(model_name)
 
-            data_uri = self._encode_local_image_as_data_uri(path)
-            logger.info("OSS not configured, using base64 data URI for local reference image")
-            return data_uri
+        try:
+            resolved = resolve_media_input(
+                path,
+                model_name=model_name,
+                modality="image",
+                backend=backend,
+                uploader=uploader,
+            )
+            return resolved.value
+        except ValueError as e:
+            if os.path.exists(path):
+                # Compatibility fallback: some legacy callers still pass absolute paths
+                # outside managed `output/` media refs.
+                if uploader.is_configured:
+                    object_key = uploader.upload_file(path, sub_path="temp/ref_images")
+                    if object_key:
+                        signed_url = uploader.sign_url_for_api(object_key)
+                        if signed_url:
+                            return signed_url
 
-        if path.startswith("http"):
-            return path
+                return self._encode_local_image_as_data_uri(path)
 
-        from ..utils.oss_utils import is_object_key
-
-        if is_object_key(path):
-            uploader = OSSImageUploader()
-            if uploader.is_configured:
-                signed_url = uploader.sign_url_for_api(path)
-                logger.info(f"Reference image (Object Key), signed URL: {signed_url[:80]}...")
-                return signed_url
-
-            logger.warning(f"OSS not configured but Object Key provided: {path}")
+            logger.warning(f"Reference image could not be resolved: {path}, reason: {e}")
             return None
 
-        logger.warning(f"Reference image not found: {path}")
-        return None
+    def _resolve_provider_backend_for_model(self, model_name: str) -> str:
+        try:
+            return resolve_provider_backend(model_name)
+        except Exception:
+            # Keep image flows resilient for models not yet registered.
+            return "dashscope"
 
     def _encode_local_image_as_data_uri(self, path: str) -> str:
         mime_type, _ = mimetypes.guess_type(path)

--- a/src/models/image.py
+++ b/src/models/image.py
@@ -10,6 +10,7 @@ import dashscope
 from dashscope import ImageSynthesis
 from ..utils import get_logger
 from ..utils.endpoints import get_provider_base_url
+from ..utils.media_refs import MEDIA_REF_UNKNOWN, classify_media_ref
 from ..utils.oss_utils import OSSImageUploader
 from ..utils.provider_media import resolve_media_input
 from ..utils.provider_registry import resolve_provider_backend
@@ -349,8 +350,9 @@ class WanxImageModel(ImageGenModel):
             )
             return resolved.value
         except ValueError as e:
-            if os.path.exists(path):
-                # Compatibility fallback: some legacy callers still pass absolute paths
+            ref_type = classify_media_ref(path)
+            if ref_type == MEDIA_REF_UNKNOWN and os.path.isabs(path) and os.path.exists(path):
+                # Compatibility fallback: only for legacy absolute local paths
                 # outside managed `output/` media refs.
                 if uploader.is_configured:
                     object_key = uploader.upload_file(path, sub_path="temp/ref_images")
@@ -367,8 +369,14 @@ class WanxImageModel(ImageGenModel):
     def _resolve_provider_backend_for_model(self, model_name: str) -> str:
         try:
             return resolve_provider_backend(model_name)
-        except Exception:
+        except (KeyError, ValueError):
             # Keep image flows resilient for models not yet registered.
+            return "dashscope"
+        except Exception as e:
+            logger.warning(
+                f"Unexpected error resolving provider backend for model {model_name}: {e}. "
+                "Falling back to dashscope."
+            )
             return "dashscope"
 
     def _encode_local_image_as_data_uri(self, path: str) -> str:

--- a/src/models/kling.py
+++ b/src/models/kling.py
@@ -5,10 +5,8 @@ Auth: JWT (HS256) using KLING_ACCESS_KEY + KLING_SECRET_KEY
 Models: kling-v2-6 (default), kling-v2-5-turbo
 """
 
-import base64
 import logging
 import os
-import re
 import time
 from typing import Dict, Any, Tuple
 
@@ -17,6 +15,8 @@ import requests
 
 from .base import VideoGenModel
 from ..utils.endpoints import get_provider_base_url
+from ..utils.oss_utils import OSSImageUploader
+from ..utils.provider_media import resolve_media_input
 
 logger = logging.getLogger(__name__)
 
@@ -53,27 +53,35 @@ class KlingModel(VideoGenModel):
             "Content-Type": "application/json",
         }
 
-    @staticmethod
-    def _resolve_image(image_path: str) -> str:
-        """Return a URL string or base64 data for a local file."""
-        if image_path.startswith(("http://", "https://", "data:")):
-            return image_path
-        if not os.path.isfile(image_path):
-            raise FileNotFoundError(f"Image file not found: {image_path}")
-        with open(image_path, "rb") as f:
-            data = base64.b64encode(f.read()).decode()
-        ext = os.path.splitext(image_path)[1].lower().lstrip(".")
-        mime_map = {"jpg": "jpeg", "jpeg": "jpeg", "png": "png", "webp": "webp"}
-        mime_sub = mime_map.get(ext, "png")
-        return f"data:image/{mime_sub};base64,{data}"
+    def _resolve_vendor_image_input(
+        self,
+        *,
+        img_url: str = None,
+        img_path: str = None,
+        model_name: str = None,
+    ) -> str:
+        """
+        Resolve Kling vendor image input via the shared provider-media layer.
 
-    @staticmethod
-    def _strip_data_prefix(value: str) -> str:
-        """Strip 'data:xxx;base64,' prefix. Kling expects pure base64."""
-        match = re.match(r"^data:[^;]+;base64,(.+)$", value, re.DOTALL)
-        if match:
-            return match.group(1)
-        return value
+        Prefer the local file when available so pipeline-downloaded or output-relative
+        refs become valid base64 payloads. If only a remote URL is available, keep the
+        legacy pass-through behavior for direct adapter calls.
+        """
+        image_ref = img_path or img_url
+        if not image_ref:
+            raise ValueError("Kling image input requires img_path or img_url")
+
+        if not img_path and isinstance(img_url, str) and img_url.startswith(("http://", "https://")):
+            return img_url
+
+        resolved = resolve_media_input(
+            image_ref,
+            model_name=model_name or self.model_name,
+            modality="image",
+            backend="vendor",
+            uploader=OSSImageUploader(),
+        )
+        return resolved.value
 
     def generate(self, prompt: str, output_path: str, img_url: str = None,
                  img_path: str = None, **kwargs) -> Tuple[str, float]:
@@ -104,9 +112,11 @@ class KlingModel(VideoGenModel):
             }
 
             # Resolve image
-            image_source = img_url or img_path
-            image_value = self._resolve_image(image_source)
-            body["image"] = self._strip_data_prefix(image_value)
+            body["image"] = self._resolve_vendor_image_input(
+                img_url=img_url,
+                img_path=img_path,
+                model_name=model_name,
+            )
 
             submit_url = f"{base_url}/videos/image2video"
             poll_base = f"{base_url}/videos/image2video"

--- a/src/models/vidu.py
+++ b/src/models/vidu.py
@@ -14,6 +14,8 @@ import requests
 
 from .base import VideoGenModel
 from ..utils.endpoints import get_provider_base_url
+from ..utils.oss_utils import OSSImageUploader
+from ..utils.provider_media import resolve_media_input
 
 logger = logging.getLogger(__name__)
 DEFAULT_T2V_MODEL = "viduq3-pro"
@@ -44,6 +46,37 @@ class ViduModel(VideoGenModel):
         }
         return mapping.get(raw_state.lower(), "pending")
 
+    def _resolve_vendor_image_input(
+        self,
+        *,
+        img_url: str = None,
+        img_path: str = None,
+        model_name: str = None,
+    ) -> str:
+        """
+        Resolve Vidu vendor image input via the shared provider-media layer.
+
+        Prefer an existing remote URL when available. For local files, require an
+        OSS-backed signed URL and fail clearly if the current environment cannot
+        provide one.
+        """
+        if isinstance(img_url, str) and img_url.startswith(("http://", "https://")):
+            image_ref = img_url
+        else:
+            image_ref = img_path or img_url
+
+        if not image_ref:
+            raise ValueError("Vidu image input requires img_path or img_url")
+
+        resolved = resolve_media_input(
+            image_ref,
+            model_name=model_name or self.model_name,
+            modality="image",
+            backend="vendor",
+            uploader=OSSImageUploader(),
+        )
+        return resolved.value
+
     def generate(self, prompt: str, output_path: str, img_url: str = None,
                  img_path: str = None, **kwargs) -> Tuple[str, float]:
         """Generate video using Vidu API (T2V or I2V)."""
@@ -59,7 +92,11 @@ class ViduModel(VideoGenModel):
         if is_i2v:
             task_id, used_model = self._submit_i2v(
                 prompt=prompt,
-                image_url=img_url or img_path,
+                image_url=self._resolve_vendor_image_input(
+                    img_url=img_url,
+                    img_path=img_path,
+                    model_name=kwargs.get("model"),
+                ),
                 model=kwargs.get("model"),
                 duration=duration,
                 resolution=resolution,

--- a/src/models/wanx.py
+++ b/src/models/wanx.py
@@ -1,3 +1,5 @@
+import base64
+import mimetypes
 import os
 import time
 import requests
@@ -64,6 +66,72 @@ class WanxModel(VideoGenModel):
         for key, value in source.items():
             if value:
                 target[key] = value
+
+    def _encode_local_image_as_data_uri(self, local_path: str) -> str:
+        mime_type, _ = mimetypes.guess_type(local_path)
+        if not mime_type:
+            mime_type = "image/png"
+        with open(local_path, "rb") as f:
+            encoded = base64.b64encode(f.read()).decode("ascii")
+        return f"data:{mime_type};base64,{encoded}"
+
+    def _resolve_sdk_image_input(
+        self,
+        *,
+        model_name: str,
+        img_path: Optional[str],
+        img_url: Optional[str],
+        uploader,
+    ) -> Optional[str]:
+        """
+        Resolve image input for SDK-based I2V calls.
+
+        This keeps DashScope provider-mode routing consistent for non-Wan model
+        names (e.g. Kling/Vidu via DashScope) and prevents raw local filesystem
+        paths from leaking into SDK payloads.
+        """
+        image_ref = img_path or img_url
+        if not image_ref:
+            return img_url
+
+        resolver_model = self._resolver_model_for_media(model_name)
+        backend = self._resolve_provider_backend_for_model(resolver_model)
+        temp_url_resolver = self._build_dashscope_temp_url_resolver(resolver_model)
+
+        try:
+            resolved_image = resolve_media_input(
+                image_ref,
+                model_name=resolver_model,
+                modality="image",
+                backend=backend,
+                uploader=uploader,
+                dashscope_temp_url_resolver=temp_url_resolver,
+            )
+            if resolved_image.headers:
+                logger.warning(
+                    "SDK path for model %s received additional media headers %s; "
+                    "continuing with resolved image value only.",
+                    model_name,
+                    list(resolved_image.headers.keys()),
+                )
+            return resolved_image.value
+        except Exception as e:
+            logger.warning(
+                "Failed to resolve SDK image input via provider-media for model %s: %s. "
+                "Falling back to raw image reference handling.",
+                model_name,
+                e,
+            )
+
+        local_candidate = None
+        if img_path and os.path.exists(img_path):
+            local_candidate = img_path
+        elif isinstance(img_url, str) and os.path.exists(img_url):
+            local_candidate = img_url
+
+        if local_candidate:
+            return self._encode_local_image_as_data_uri(local_candidate)
+        return img_url
 
     def _create_dashscope_temp_url(self, local_path: str, model_name: str) -> str:
         """
@@ -285,6 +353,13 @@ class WanxModel(VideoGenModel):
                 )
             else:
                 # Use SDK for other models
+                if img_path or img_url:
+                    img_url = self._resolve_sdk_image_input(
+                        model_name=final_model_name,
+                        img_path=img_path,
+                        img_url=img_url,
+                        uploader=uploader,
+                    )
                 video_url = self._generate_sdk(
                     prompt=prompt,
                     model_name=final_model_name,

--- a/src/models/wanx.py
+++ b/src/models/wanx.py
@@ -8,9 +8,11 @@ from .base import VideoGenModel
 from ..utils import get_logger
 from ..utils.endpoints import get_provider_base_url
 
-from typing import Tuple
+from typing import Callable, Dict, List, Mapping, Optional, Tuple
 
 from ..utils.oss_utils import OSSImageUploader
+from ..utils.provider_media import resolve_media_input, resolve_media_inputs
+from ..utils.provider_registry import resolve_provider_backend
 
 logger = get_logger(__name__)
 
@@ -27,6 +29,112 @@ class WanxModel(VideoGenModel):
         if not api_key:
             logger.warning("Dashscope API Key not found in config or environment variables.")
         return api_key
+
+    def _resolve_provider_backend_for_model(self, model_name: str) -> str:
+        try:
+            return resolve_provider_backend(model_name)
+        except (KeyError, ValueError):
+            return "dashscope"
+        except Exception as e:
+            logger.warning(
+                "Unexpected error resolving provider backend for model %s: %s. "
+                "Falling back to dashscope.",
+                model_name,
+                e,
+            )
+            return "dashscope"
+
+    def _resolver_model_for_media(self, model_name: str) -> str:
+        # `wan2.5-i2v` follows the same DashScope media transport profile as `wan2.6-i2v`.
+        if (model_name or "").strip().lower() == "wan2.5-i2v":
+            return "wan2.6-i2v"
+        return model_name
+
+    def _build_dashscope_temp_url_resolver(self, model_name: str) -> Callable[[str], str]:
+        return lambda local_path: self._create_dashscope_temp_url(local_path, model_name)
+
+    @staticmethod
+    def _merge_media_headers(target: Dict[str, str], source: Optional[Mapping[str, str]]) -> None:
+        if not source:
+            return
+        for key, value in source.items():
+            if value:
+                target[key] = value
+
+    def _create_dashscope_temp_url(self, local_path: str, model_name: str) -> str:
+        """
+        Upload a local file to DashScope temporary storage and return an `oss://` URL.
+        """
+        if not os.path.exists(local_path):
+            raise FileNotFoundError(f"Local media file not found: {local_path}")
+
+        base = get_provider_base_url("DASHSCOPE")
+        policy_url = f"{base}/api/v1/uploads"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+
+        policy_resp = requests.get(
+            policy_url,
+            params={"action": "getPolicy", "model": model_name},
+            headers=headers,
+            timeout=30,
+        )
+        if policy_resp.status_code != 200:
+            raise RuntimeError(
+                f"Failed to get DashScope upload policy (HTTP {policy_resp.status_code}): "
+                f"{policy_resp.text}"
+            )
+
+        policy_body = policy_resp.json()
+        policy_data = policy_body.get("output") or policy_body.get("data") or policy_body
+
+        upload_host = policy_data.get("upload_host") or policy_data.get("host")
+        if not upload_host:
+            raise RuntimeError(f"DashScope upload policy missing upload_host: {policy_body}")
+
+        upload_dir = policy_data.get("upload_dir") or policy_data.get("dir") or ""
+        object_key = (
+            policy_data.get("upload_file_path")
+            or policy_data.get("object_key")
+            or policy_data.get("key")
+            or policy_data.get("file_path")
+        )
+        if not object_key:
+            filename = os.path.basename(local_path)
+            object_key = f"{upload_dir.rstrip('/')}/{filename}" if upload_dir else filename
+
+        form_data: Dict[str, str] = {"key": object_key}
+        field_map = {
+            "policy": "policy",
+            "signature": "signature",
+            "oss_access_key_id": "OSSAccessKeyId",
+            "x_oss_security_token": "x-oss-security-token",
+            "x_oss_signature_version": "x-oss-signature-version",
+            "x_oss_credential": "x-oss-credential",
+            "x_oss_date": "x-oss-date",
+            "x_oss_signature": "x-oss-signature",
+            "success_action_status": "success_action_status",
+            "callback": "callback",
+        }
+        for source_key, target_key in field_map.items():
+            value = policy_data.get(source_key)
+            if value:
+                form_data[target_key] = str(value)
+
+        for key, value in policy_data.items():
+            if key.startswith("x-oss-") and value and key not in form_data:
+                form_data[key] = str(value)
+
+        with open(local_path, "rb") as file_handle:
+            files = {"file": (os.path.basename(local_path), file_handle)}
+            upload_resp = requests.post(upload_host, data=form_data, files=files, timeout=120)
+
+        if upload_resp.status_code not in (200, 201, 204):
+            raise RuntimeError(
+                f"Failed to upload temp media to DashScope (HTTP {upload_resp.status_code}): "
+                f"{upload_resp.text}"
+            )
+
+        return f"oss://{object_key}"
 
     def generate(self, prompt: str, output_path: str, img_path: str = None, model_name: str = None, **kwargs) ->Tuple[str, float]:
         # Determine model - allow explicit override via model_name param or 'model' kwarg
@@ -73,46 +181,41 @@ class WanxModel(VideoGenModel):
         try:
             api_start_time = time.time()
 
-            # Get image URL (upload local file if needed, or convert Object Key to signed URL)
             img_url = kwargs.get('img_url')
             uploader = OSSImageUploader()
-            
-            if img_path:
-                if os.path.exists(img_path):
-                    # Local file - upload to OSS and get signed URL
-                    if uploader.is_configured:
-                        logger.info(f"Uploading input image to OSS: {img_path}")
-                        object_key = uploader.upload_file(img_path, sub_path="temp/i2v_input")
-                        if object_key:
-                            img_url = uploader.sign_url_for_api(object_key)
-                            logger.info(f"Input image uploaded, signed URL: {img_url[:80]}...")
-                        else:
-                            raise RuntimeError("Failed to upload input image to OSS")
-                    else:
-                        raise RuntimeError("OSS not configured, cannot upload input image for I2V")
-                elif img_path.startswith("http"):
-                    # Already a URL
-                    img_url = img_path
-                elif "/" in img_path and not img_path.startswith("output/"):
-                    # Might be an Object Key, generate signed URL
-                    if uploader.is_configured:
-                        img_url = uploader.sign_url_for_api(img_path)
-                        logger.info(f"Input image (Object Key from img_path), signed URL: {img_url[:80]}...")
-                    else:
-                        raise RuntimeError(f"OSS not configured, cannot sign Object Key: {img_path}")
-                else:
-                    raise ValueError(f"Input image not found: {img_path}")
-            elif img_url:
-                # If img_url is provided but img_path is not, check if img_url is an Object Key
-                if not img_url.startswith("http") and "/" in img_url and not img_url.startswith("output/"):
-                    if uploader.is_configured:
-                        img_url = uploader.sign_url_for_api(img_url)
-                        logger.info(f"Input image (Object Key from img_url), signed URL: {img_url[:80]}...")
-                    else:
-                        logger.warning(f"OSS not configured, cannot sign Object Key in img_url: {img_url}")
+            extra_media_headers: Dict[str, str] = {}
 
             # Use HTTP API for wan2.6-i2v, wan2.5-i2v, or wan2.6-r2v
             if final_model_name in ['wan2.6-i2v', 'wan2.6-i2v-flash', 'wan2.5-i2v']:
+                resolver_model = self._resolver_model_for_media(final_model_name)
+                backend = self._resolve_provider_backend_for_model(resolver_model)
+                temp_url_resolver = self._build_dashscope_temp_url_resolver(resolver_model)
+
+                image_ref = img_path or img_url
+                if image_ref:
+                    resolved_image = resolve_media_input(
+                        image_ref,
+                        model_name=resolver_model,
+                        modality="image",
+                        backend=backend,
+                        uploader=uploader,
+                        dashscope_temp_url_resolver=temp_url_resolver,
+                    )
+                    img_url = resolved_image.value
+                    self._merge_media_headers(extra_media_headers, resolved_image.headers)
+
+                if audio_url:
+                    resolved_audio = resolve_media_input(
+                        audio_url,
+                        model_name=resolver_model,
+                        modality="audio",
+                        backend=backend,
+                        uploader=uploader,
+                        dashscope_temp_url_resolver=temp_url_resolver,
+                    )
+                    audio_url = resolved_audio.value
+                    self._merge_media_headers(extra_media_headers, resolved_audio.headers)
+
                 # Get shot_type from kwargs (only for wan I2V models)
                 shot_type = kwargs.get('shot_type', 'single')
                 video_url = self._generate_wan_i2v_http(
@@ -126,54 +229,30 @@ class WanxModel(VideoGenModel):
                     audio_url=audio_url,
                     watermark=watermark,
                     seed=seed,
-                    shot_type=shot_type
+                    shot_type=shot_type,
+                    extra_headers=extra_media_headers,
                 )
             elif final_model_name == 'wan2.6-r2v':
                 # R2V generation
                 ref_video_urls = kwargs.get('ref_video_urls', [])
                 if not ref_video_urls:
                     raise ValueError("ref_video_urls is required for wan2.6-r2v")
-                
-                # Process ref_video_urls: Upload local files or sign Object Keys
-                processed_ref_urls = []
-                for ref_url in ref_video_urls:
-                    final_url = ref_url
-                    
-                    # Check if it's a local file
-                    local_path = None
-                    if not ref_url.startswith("http"):
-                        # Check relative to output dir
-                        potential_path = os.path.join("output", ref_url)
-                        if os.path.exists(potential_path):
-                            local_path = potential_path
-                        # Check absolute path or relative to CWD
-                        elif os.path.exists(ref_url):
-                            local_path = ref_url
-                    
-                    if local_path:
-                        # Local file - upload to OSS
-                        if uploader.is_configured:
-                            logger.info(f"Uploading reference video to OSS: {local_path}")
-                            object_key = uploader.upload_file(local_path, sub_path="temp/r2v_input")
-                            if object_key:
-                                final_url = uploader.sign_url_for_api(object_key)
-                                logger.info(f"Reference video uploaded, signed URL: {final_url[:80]}...")
-                            else:
-                                raise RuntimeError(f"Failed to upload reference video: {local_path}")
-                        else:
-                            raise RuntimeError("OSS not configured, cannot upload local reference video for R2V")
-                    
-                    elif not ref_url.startswith("http") and "/" in ref_url and not ref_url.startswith("output/"):
-                        # Likely an Object Key
-                        if uploader.is_configured:
-                            final_url = uploader.sign_url_for_api(ref_url)
-                            logger.info(f"Reference video (Object Key), signed URL: {final_url[:80]}...")
-                        else:
-                            logger.warning(f"OSS not configured, cannot sign Object Key: {ref_url}")
-                            
-                    processed_ref_urls.append(final_url)
-                
-                ref_video_urls = processed_ref_urls
+
+                resolver_model = self._resolver_model_for_media(final_model_name)
+                backend = self._resolve_provider_backend_for_model(resolver_model)
+                temp_url_resolver = self._build_dashscope_temp_url_resolver(resolver_model)
+
+                resolved_ref_urls = resolve_media_inputs(
+                    ref_video_urls,
+                    model_name=resolver_model,
+                    modality="reference_video",
+                    backend=backend,
+                    uploader=uploader,
+                    dashscope_temp_url_resolver=temp_url_resolver,
+                )
+                ref_video_urls = [item.value for item in resolved_ref_urls]
+                for resolved_item in resolved_ref_urls:
+                    self._merge_media_headers(extra_media_headers, resolved_item.headers)
                 
                 shot_type = kwargs.get('shot_type', 'multi') # Default to multi for R2V as per PRD
                 
@@ -185,7 +264,8 @@ class WanxModel(VideoGenModel):
                     duration=duration,
                     audio=kwargs.get('audio', True), # Default to True for R2V
                     shot_type=shot_type,
-                    seed=seed
+                    seed=seed,
+                    extra_headers=extra_media_headers,
                 )
             else:
                 # Use SDK for other models
@@ -223,7 +303,8 @@ class WanxModel(VideoGenModel):
                                   duration: int = 5, prompt_extend: bool = True,
                                   negative_prompt: str = None, audio_url: str = None,
                                   watermark: bool = False, seed: int = None,
-                                  shot_type: str = "single") -> str:
+                                  shot_type: str = "single",
+                                  extra_headers: Optional[Mapping[str, str]] = None) -> str:
         """Generate video using Wan I2V (2.5 or 2.6) via HTTP API (asynchronous with polling)."""
         base = get_provider_base_url("DASHSCOPE")
         create_url = f"{base}/api/v1/services/aigc/video-generation/video-synthesis"
@@ -233,6 +314,8 @@ class WanxModel(VideoGenModel):
             "Authorization": f"Bearer {self.api_key}",
             "X-DashScope-Async": "enable"  # Required for async mode
         }
+        if extra_headers:
+            headers.update(dict(extra_headers))
         
         payload = {
             "model": model_name,  # Use passed model name (wan2.5-i2v or wan2.6-i2v)
@@ -328,7 +411,8 @@ class WanxModel(VideoGenModel):
     def _generate_wan_r2v_http(self, prompt: str, ref_video_urls: list, model_name: str = "wan2.6-r2v",
                                   size: str = "1280*720", 
                                   duration: int = 5, audio: bool = True,
-                                  shot_type: str = "multi", seed: int = None) -> str:
+                                  shot_type: str = "multi", seed: int = None,
+                                  extra_headers: Optional[Mapping[str, str]] = None) -> str:
         """Generate video using Wan R2V via HTTP API (asynchronous with polling)."""
         base = get_provider_base_url("DASHSCOPE")
         create_url = f"{base}/api/v1/services/aigc/video-generation/video-synthesis"
@@ -338,6 +422,8 @@ class WanxModel(VideoGenModel):
             "Authorization": f"Bearer {self.api_key}",
             "X-DashScope-Async": "enable"
         }
+        if extra_headers:
+            headers.update(dict(extra_headers))
         
         payload = {
             "model": model_name,

--- a/src/models/wanx.py
+++ b/src/models/wanx.py
@@ -34,6 +34,10 @@ class WanxModel(VideoGenModel):
         try:
             return resolve_provider_backend(model_name)
         except (KeyError, ValueError):
+            logger.debug(
+                "Provider backend not registered for model %s, defaulting to dashscope.",
+                model_name,
+            )
             return "dashscope"
         except Exception as e:
             logger.warning(
@@ -201,6 +205,18 @@ class WanxModel(VideoGenModel):
                         uploader=uploader,
                         dashscope_temp_url_resolver=temp_url_resolver,
                     )
+                    # For Wan I2V, keep local no-OSS image inputs URL-based just like audio/video
+                    # (oss:// + X-DashScope-OssResourceResolve), not data URIs.
+                    if resolved_image.value.startswith("data:image/"):
+                        resolved_image = resolve_media_input(
+                            image_ref,
+                            model_name=resolver_model,
+                            modality="reference_video",
+                            backend=backend,
+                            uploader=uploader,
+                            dashscope_temp_url_resolver=temp_url_resolver,
+                        )
+
                     img_url = resolved_image.value
                     self._merge_media_headers(extra_media_headers, resolved_image.headers)
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -21,20 +21,36 @@ def setup_logging(level=logging.INFO, log_file=None):
     
     # If no log file specified, use default in user directory
     if log_file is None:
-        log_file = os.path.join(get_log_dir(), "app.log")
+        try:
+            log_file = os.path.join(get_log_dir(), "app.log")
+        except OSError as exc:
+            print(
+                f"WARNING: Log directory unavailable in user home: {exc}. "
+                "Falling back to console logging.",
+                file=sys.stderr,
+            )
+            log_file = None
     
     # 如果指定了日志文件，添加文件处理器
     if log_file:
-        # 确保日志目录存在
-        log_dir = os.path.dirname(log_file)
-        if log_dir:
-            os.makedirs(log_dir, exist_ok=True)
-        
-        file_handler = logging.FileHandler(log_file, mode='a', encoding='utf-8')
-        file_handler.setFormatter(
-            logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-        )
-        handlers.append(file_handler)
+        try:
+            # 确保日志目录存在
+            log_dir = os.path.dirname(log_file)
+            if log_dir:
+                os.makedirs(log_dir, exist_ok=True)
+
+            file_handler = logging.FileHandler(log_file, mode='a', encoding='utf-8')
+            file_handler.setFormatter(
+                logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            )
+            handlers.append(file_handler)
+        except OSError as exc:
+            # In restricted environments (tests/sandbox), fallback to console-only logging.
+            print(
+                f"WARNING: File logging unavailable at '{log_file}': {exc}. "
+                "Falling back to console logging.",
+                file=sys.stderr,
+            )
     
     # 添加控制台处理器（会被重定向到日志文件）
     console_handler = logging.StreamHandler(sys.stdout)

--- a/src/utils/media_refs.py
+++ b/src/utils/media_refs.py
@@ -17,6 +17,7 @@ LOCAL_MEDIA_PREFIXES = (
 MEDIA_REF_LOCAL_PATH = "local_path"
 MEDIA_REF_OBJECT_KEY = "object_key"
 MEDIA_REF_REMOTE_URL = "remote_url"
+MEDIA_REF_BLOB_URL = "blob_url"
 MEDIA_REF_DATA_URI = "data_uri"
 MEDIA_REF_UNKNOWN = "unknown"
 
@@ -62,7 +63,10 @@ def classify_media_ref(
     if raw.startswith("data:"):
         return MEDIA_REF_DATA_URI
 
-    if raw.startswith(("http://", "https://", "blob:")):
+    if raw.startswith("blob:"):
+        return MEDIA_REF_BLOB_URL
+
+    if raw.startswith(("http://", "https://")):
         return MEDIA_REF_REMOTE_URL
 
     output_root = _output_root(project_root)
@@ -106,7 +110,7 @@ def resolve_local_media_path(value: str, *, project_root: Optional[str] = None) 
 
 
 def is_remote_media_ref(value: str) -> bool:
-    return classify_media_ref(value) == MEDIA_REF_REMOTE_URL
+    return classify_media_ref(value) in {MEDIA_REF_REMOTE_URL, MEDIA_REF_BLOB_URL}
 
 
 def is_stable_project_media_ref(value: str) -> bool:

--- a/src/utils/media_refs.py
+++ b/src/utils/media_refs.py
@@ -1,0 +1,117 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+
+LOCAL_MEDIA_PREFIXES = (
+    "assets/",
+    "storyboard/",
+    "video/",
+    "audio/",
+    "export/",
+    "uploads/",
+    "output/",
+    "outputs/",
+)
+
+MEDIA_REF_LOCAL_PATH = "local_path"
+MEDIA_REF_OBJECT_KEY = "object_key"
+MEDIA_REF_REMOTE_URL = "remote_url"
+MEDIA_REF_DATA_URI = "data_uri"
+MEDIA_REF_UNKNOWN = "unknown"
+
+
+def _project_root(project_root: Optional[str] = None) -> Path:
+    if project_root:
+        return Path(project_root).resolve()
+    # src/utils/media_refs.py -> repo root
+    return Path(__file__).resolve().parents[2]
+
+
+def _output_root(project_root: Optional[str] = None) -> Path:
+    return _project_root(project_root) / "output"
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _normalized_oss_base_path(oss_base_path: Optional[str] = None) -> str:
+    value = oss_base_path if oss_base_path is not None else os.getenv("OSS_BASE_PATH", "lumenx")
+    return str(value).strip().strip("'\"/ ")
+
+
+def classify_media_ref(
+    value: str,
+    *,
+    oss_base_path: Optional[str] = None,
+    project_root: Optional[str] = None,
+) -> str:
+    """Classify media reference string used in project state."""
+    if not isinstance(value, str):
+        return MEDIA_REF_UNKNOWN
+
+    raw = value.strip()
+    if not raw:
+        return MEDIA_REF_UNKNOWN
+
+    if raw.startswith("data:"):
+        return MEDIA_REF_DATA_URI
+
+    if raw.startswith(("http://", "https://", "blob:")):
+        return MEDIA_REF_REMOTE_URL
+
+    output_root = _output_root(project_root)
+    if os.path.isabs(raw):
+        return MEDIA_REF_LOCAL_PATH if _is_under(Path(raw), output_root) else MEDIA_REF_UNKNOWN
+
+    relative = raw.lstrip("/")
+    if relative.startswith(LOCAL_MEDIA_PREFIXES):
+        return MEDIA_REF_LOCAL_PATH
+
+    base_path = _normalized_oss_base_path(oss_base_path)
+    if base_path and relative.startswith(f"{base_path}/"):
+        return MEDIA_REF_OBJECT_KEY
+
+    return MEDIA_REF_UNKNOWN
+
+
+def resolve_local_media_path(value: str, *, project_root: Optional[str] = None) -> Optional[str]:
+    """
+    Resolve a local media reference to an absolute filesystem path under output/.
+    Returns None when the input is not a local media reference.
+    """
+    if classify_media_ref(value, project_root=project_root) != MEDIA_REF_LOCAL_PATH:
+        return None
+
+    raw = value.strip()
+    output_root = _output_root(project_root).resolve()
+
+    if os.path.isabs(raw):
+        abs_path = Path(raw).resolve()
+        return str(abs_path) if _is_under(abs_path, output_root) else None
+
+    relative = raw.lstrip("/")
+    if relative.startswith("output/"):
+        relative = relative[len("output/") :]
+    elif relative.startswith("outputs/"):
+        relative = relative[len("outputs/") :]
+
+    abs_path = (output_root / relative).resolve()
+    return str(abs_path) if _is_under(abs_path, output_root) else None
+
+
+def is_remote_media_ref(value: str) -> bool:
+    return classify_media_ref(value) == MEDIA_REF_REMOTE_URL
+
+
+def is_stable_project_media_ref(value: str) -> bool:
+    return classify_media_ref(value) in {
+        MEDIA_REF_LOCAL_PATH,
+        MEDIA_REF_OBJECT_KEY,
+        MEDIA_REF_REMOTE_URL,
+    }

--- a/src/utils/oss_utils.py
+++ b/src/utils/oss_utils.py
@@ -4,6 +4,7 @@ import hashlib
 import time
 from typing import Optional, Tuple
 from . import get_logger
+from .media_refs import classify_media_ref, MEDIA_REF_LOCAL_PATH, MEDIA_REF_OBJECT_KEY
 
 logger = get_logger(__name__)
 
@@ -33,31 +34,10 @@ def is_object_key(value: str) -> bool:
     """
     Check if a string value is an OSS Object Key (not a full URL or local path).
     """
-    if not value or not isinstance(value, str):
-        return False
-    # Skip full URLs
-    if value.startswith(("http://", "https://", "blob:", "data:")):
-        return False
-    # Skip empty or whitespace-only
-    if not value.strip():
-        return False
-    
-    # Skip local paths (these start with known local directories)
-    # Be very inclusive here to avoid signing local files
-    local_prefixes = (
-        "assets/", "storyboard/", "video/", "audio/", "export/", "uploads/", "output/", "outputs/",
-        "/assets/", "/storyboard/", "/video/", "/audio/", "/export/", "/uploads/", "/output/", "/outputs/"
+    return (
+        classify_media_ref(value, oss_base_path=get_oss_base_path())
+        == MEDIA_REF_OBJECT_KEY
     )
-    if value.startswith(local_prefixes):
-        return False
-    
-    # Get the current OSS base path and ensure it ends with a single slash
-    # Strip quotes and slashes to be robust
-    base_path = get_oss_base_path().strip("'\"/")
-    
-    # Object keys MUST start with the OSS base path (e.g., 'lumenx/')
-    # This is the ONLY valid check. Do NOT add a fallback that might match local paths.
-    return value.startswith(f"{base_path}/")
 
 
 
@@ -69,12 +49,10 @@ def is_object_key(value: str) -> bool:
 
 def is_local_path(value: str) -> bool:
     """Check if a string is a local file path (relative or absolute)."""
-    if not value or not isinstance(value, str):
-        return False
-    if value.startswith("http://") or value.startswith("https://"):
-        return False
-    # Check if it's a relative path starting with known directories
-    return value.startswith(("assets/", "storyboard/", "video/", "audio/", "export/", "uploads/", "output/"))
+    return (
+        classify_media_ref(value, oss_base_path=get_oss_base_path())
+        == MEDIA_REF_LOCAL_PATH
+    )
 
 
 class OSSImageUploader:
@@ -332,4 +310,3 @@ def convert_local_path_to_object_key(local_path: str, project_id: str = None) ->
         return f"{base_path}/{project_id}/{local_path}"
     else:
         return f"{base_path}/{local_path}"
-

--- a/src/utils/oss_utils.py
+++ b/src/utils/oss_utils.py
@@ -39,14 +39,6 @@ def is_object_key(value: str) -> bool:
         == MEDIA_REF_OBJECT_KEY
     )
 
-
-
-
-
-
-
-
-
 def is_local_path(value: str) -> bool:
     """Check if a string is a local file path (relative or absolute)."""
     return (

--- a/src/utils/provider_media.py
+++ b/src/utils/provider_media.py
@@ -1,8 +1,8 @@
 import base64
 import mimetypes
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence
+from types import MappingProxyType
+from typing import Callable, Dict, List, Mapping, Optional, Sequence
 
 from .media_refs import (
     MEDIA_REF_BLOB_URL,
@@ -27,9 +27,13 @@ _DASHSCOPE_TEMP_SUB_PATH = "temp/provider_media"
 @dataclass(frozen=True)
 class ResolvedMediaInput:
     value: str
-    headers: Dict[str, str] = field(default_factory=dict)
+    headers: Mapping[str, str] = field(default_factory=dict)
     source_ref: Optional[str] = None
     media_ref_type: Optional[str] = None
+
+    def __post_init__(self):
+        immutable_headers = MappingProxyType(dict(self.headers or {}))
+        object.__setattr__(self, "headers", immutable_headers)
 
 
 def _normalize_modality(modality: str) -> str:
@@ -88,12 +92,6 @@ def _upload_then_sign(local_path: str, uploader, sub_path: str = _DASHSCOPE_TEMP
     if not object_key:
         return None
     return uploader.sign_url_for_api(object_key)
-
-
-def _default_dashscope_temp_url_resolver(local_path: str) -> str:
-    # DashScope supports local `file://` references for some media APIs.
-    # Caller can inject an alternative resolver to mint `oss://` temp URLs.
-    return Path(local_path).resolve().as_uri()
 
 
 def _resolved(value: str, *, source_ref: str, media_ref_type: str, headers: Optional[Dict[str, str]] = None) -> ResolvedMediaInput:
@@ -161,8 +159,15 @@ def _resolve_dashscope_temp_url(
         if signed_url:
             return _resolved(signed_url, source_ref=ref, media_ref_type=ref_type)
 
-        resolver = dashscope_temp_url_resolver or _default_dashscope_temp_url_resolver
+        if dashscope_temp_url_resolver is None:
+            raise ValueError(
+                "DashScope URL-based media input requires OSS or a dashscope_temp_url_resolver "
+                "for local media. Configure OSS or provide a DashScope temp-url resolver."
+            )
+        resolver = dashscope_temp_url_resolver
         temp_url = resolver(local_path)
+        if not isinstance(temp_url, str) or not temp_url.strip():
+            raise ValueError("dashscope_temp_url_resolver returned an empty URL.")
         headers = {}
         if temp_url.startswith("oss://"):
             headers[RESOLVE_HEADER_DASHSCOPE_OSS_RESOURCE] = "enable"

--- a/src/utils/provider_media.py
+++ b/src/utils/provider_media.py
@@ -1,0 +1,314 @@
+import base64
+import mimetypes
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Sequence
+
+from .media_refs import (
+    MEDIA_REF_BLOB_URL,
+    MEDIA_REF_DATA_URI,
+    MEDIA_REF_LOCAL_PATH,
+    MEDIA_REF_OBJECT_KEY,
+    MEDIA_REF_REMOTE_URL,
+    classify_media_ref,
+    resolve_local_media_path,
+)
+from .provider_registry import (
+    SUPPORTED_PROVIDER_BACKENDS,
+    ProviderRegistry,
+    get_default_provider_registry,
+)
+
+
+RESOLVE_HEADER_DASHSCOPE_OSS_RESOURCE = "X-DashScope-OssResourceResolve"
+_DASHSCOPE_TEMP_SUB_PATH = "temp/provider_media"
+
+
+@dataclass(frozen=True)
+class ResolvedMediaInput:
+    value: str
+    headers: Dict[str, str] = field(default_factory=dict)
+    source_ref: Optional[str] = None
+    media_ref_type: Optional[str] = None
+
+
+def _normalize_modality(modality: str) -> str:
+    value = (modality or "").strip().lower()
+    if value in {"image", "audio", "video", "reference_video"}:
+        return value
+    raise ValueError(f"Unsupported modality '{modality}'")
+
+
+def _mode_for_modality(family_config, backend: str, modality: str) -> str:
+    if modality == "image":
+        mode = family_config.image_input_mode.get(backend)
+    elif modality == "audio":
+        mode = family_config.audio_input_mode.get(backend)
+    else:
+        mode = family_config.reference_video_input_mode.get(backend)
+
+    if mode:
+        return mode
+    raise ValueError(
+        f"Model family '{family_config.model_family}' does not support backend "
+        f"'{backend}' for modality '{modality}'"
+    )
+
+
+def _encode_image_as_data_uri(local_path: str) -> str:
+    mime_type, _ = mimetypes.guess_type(local_path)
+    if not mime_type:
+        mime_type = "image/png"
+    with open(local_path, "rb") as f:
+        encoded = base64.b64encode(f.read()).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def _encode_local_file_base64(local_path: str) -> str:
+    with open(local_path, "rb") as f:
+        return base64.b64encode(f.read()).decode("ascii")
+
+
+def _strip_data_uri_prefix(value: str) -> str:
+    if ";base64," in value and value.startswith("data:"):
+        return value.split(";base64,", 1)[1]
+    return value
+
+
+def _signed_url_from_object_key(ref: str, uploader) -> Optional[str]:
+    if not uploader or not getattr(uploader, "is_configured", False):
+        return None
+    return uploader.sign_url_for_api(ref)
+
+
+def _upload_then_sign(local_path: str, uploader, sub_path: str = _DASHSCOPE_TEMP_SUB_PATH) -> Optional[str]:
+    if not uploader or not getattr(uploader, "is_configured", False):
+        return None
+    object_key = uploader.upload_file(local_path, sub_path=sub_path)
+    if not object_key:
+        return None
+    return uploader.sign_url_for_api(object_key)
+
+
+def _default_dashscope_temp_url_resolver(local_path: str) -> str:
+    # DashScope supports local `file://` references for some media APIs.
+    # Caller can inject an alternative resolver to mint `oss://` temp URLs.
+    return Path(local_path).resolve().as_uri()
+
+
+def _resolved(value: str, *, source_ref: str, media_ref_type: str, headers: Optional[Dict[str, str]] = None) -> ResolvedMediaInput:
+    return ResolvedMediaInput(
+        value=value,
+        headers=headers or {},
+        source_ref=source_ref,
+        media_ref_type=media_ref_type,
+    )
+
+
+def _resolve_dashscope_image(
+    ref: str,
+    ref_type: str,
+    *,
+    uploader,
+    local_path: Optional[str],
+) -> ResolvedMediaInput:
+    if ref_type == MEDIA_REF_REMOTE_URL:
+        return _resolved(ref, source_ref=ref, media_ref_type=ref_type)
+    if ref_type == MEDIA_REF_DATA_URI:
+        return _resolved(ref, source_ref=ref, media_ref_type=ref_type)
+    if ref_type == MEDIA_REF_OBJECT_KEY:
+        signed_url = _signed_url_from_object_key(ref, uploader)
+        if signed_url:
+            return _resolved(signed_url, source_ref=ref, media_ref_type=ref_type)
+        raise ValueError(
+            "DashScope image input received an OSS object key but OSS is not configured. "
+            "Configure OSS or pass a local/remote image reference."
+        )
+    if ref_type == MEDIA_REF_LOCAL_PATH:
+        if not local_path:
+            raise ValueError(f"Unable to resolve local media path for '{ref}'")
+        signed_url = _upload_then_sign(local_path, uploader)
+        if signed_url:
+            return _resolved(signed_url, source_ref=ref, media_ref_type=ref_type)
+        return _resolved(_encode_image_as_data_uri(local_path), source_ref=ref, media_ref_type=ref_type)
+    if ref_type == MEDIA_REF_BLOB_URL:
+        raise ValueError("Blob URLs are ephemeral and unsupported for backend media resolution.")
+    raise ValueError(f"Unsupported media reference for DashScope image input: '{ref}'")
+
+
+def _resolve_dashscope_temp_url(
+    ref: str,
+    ref_type: str,
+    *,
+    uploader,
+    local_path: Optional[str],
+    dashscope_temp_url_resolver: Optional[Callable[[str], str]],
+) -> ResolvedMediaInput:
+    if ref_type == MEDIA_REF_REMOTE_URL:
+        return _resolved(ref, source_ref=ref, media_ref_type=ref_type)
+    if ref_type == MEDIA_REF_OBJECT_KEY:
+        signed_url = _signed_url_from_object_key(ref, uploader)
+        if signed_url:
+            return _resolved(signed_url, source_ref=ref, media_ref_type=ref_type)
+        raise ValueError(
+            "DashScope URL-based media input received an OSS object key but OSS is not configured. "
+            "Configure OSS or use a local path that can be resolved via temporary URL."
+        )
+    if ref_type == MEDIA_REF_LOCAL_PATH:
+        if not local_path:
+            raise ValueError(f"Unable to resolve local media path for '{ref}'")
+        signed_url = _upload_then_sign(local_path, uploader)
+        if signed_url:
+            return _resolved(signed_url, source_ref=ref, media_ref_type=ref_type)
+
+        resolver = dashscope_temp_url_resolver or _default_dashscope_temp_url_resolver
+        temp_url = resolver(local_path)
+        headers = {}
+        if temp_url.startswith("oss://"):
+            headers[RESOLVE_HEADER_DASHSCOPE_OSS_RESOURCE] = "enable"
+        return _resolved(temp_url, source_ref=ref, media_ref_type=ref_type, headers=headers)
+    if ref_type == MEDIA_REF_BLOB_URL:
+        raise ValueError("Blob URLs are ephemeral and unsupported for backend media resolution.")
+    if ref_type == MEDIA_REF_DATA_URI:
+        raise ValueError("Data URI is not supported for DashScope URL-based media input.")
+    raise ValueError(f"Unsupported media reference for DashScope URL-based media input: '{ref}'")
+
+
+def _resolve_vendor_kling_image(
+    ref: str,
+    ref_type: str,
+    *,
+    local_path: Optional[str],
+) -> ResolvedMediaInput:
+    if ref_type == MEDIA_REF_LOCAL_PATH:
+        if not local_path:
+            raise ValueError(f"Unable to resolve local media path for '{ref}'")
+        return _resolved(_encode_local_file_base64(local_path), source_ref=ref, media_ref_type=ref_type)
+    if ref_type == MEDIA_REF_DATA_URI:
+        return _resolved(_strip_data_uri_prefix(ref), source_ref=ref, media_ref_type=ref_type)
+    raise ValueError(
+        "Kling vendor image input requires local file or data URI so it can be sent as base64."
+    )
+
+
+def _resolve_vendor_url_mode(
+    ref: str,
+    ref_type: str,
+    *,
+    uploader,
+    local_path: Optional[str],
+    provider_label: str,
+    modality: str,
+) -> ResolvedMediaInput:
+    if ref_type == MEDIA_REF_REMOTE_URL:
+        return _resolved(ref, source_ref=ref, media_ref_type=ref_type)
+    if ref_type == MEDIA_REF_OBJECT_KEY:
+        signed_url = _signed_url_from_object_key(ref, uploader)
+        if signed_url:
+            return _resolved(signed_url, source_ref=ref, media_ref_type=ref_type)
+    if ref_type == MEDIA_REF_LOCAL_PATH and local_path:
+        signed_url = _upload_then_sign(local_path, uploader)
+        if signed_url:
+            return _resolved(signed_url, source_ref=ref, media_ref_type=ref_type)
+
+    raise ValueError(
+        f"{provider_label} vendor {modality} input requires a URL-compatible media source. "
+        "Configure OSS for local/object-key references, or switch provider mode to dashscope."
+    )
+
+
+def resolve_media_input(
+    ref: str,
+    *,
+    model_name: str,
+    modality: str,
+    backend: Optional[str] = None,
+    uploader=None,
+    registry: Optional[ProviderRegistry] = None,
+    project_root: Optional[str] = None,
+    oss_base_path: Optional[str] = None,
+    dashscope_temp_url_resolver: Optional[Callable[[str], str]] = None,
+) -> ResolvedMediaInput:
+    """
+    Resolve a stable project-side media reference to a provider-ready input payload.
+    This function is pure with respect to caller state: it does not mutate `ref`.
+    """
+    if not isinstance(ref, str) or not ref.strip():
+        raise ValueError("ref must be a non-empty string")
+
+    active_registry = registry or get_default_provider_registry()
+    family = active_registry.get_family_config(model_name)
+    resolved_backend = (backend or active_registry.resolve_backend(model_name)).strip().lower()
+    if resolved_backend not in SUPPORTED_PROVIDER_BACKENDS:
+        raise ValueError(f"Unsupported backend '{resolved_backend}'")
+
+    normalized_modality = _normalize_modality(modality)
+    mode = _mode_for_modality(family, resolved_backend, normalized_modality)
+
+    ref_type = classify_media_ref(
+        ref,
+        project_root=project_root,
+        oss_base_path=oss_base_path,
+    )
+    local_path = resolve_local_media_path(ref, project_root=project_root)
+
+    if mode in {"dashscope_multimodal_message", "dashscope_image_to_video"}:
+        return _resolve_dashscope_image(
+            ref,
+            ref_type,
+            uploader=uploader,
+            local_path=local_path,
+        )
+    if mode == "dashscope_temp_file_url":
+        return _resolve_dashscope_temp_url(
+            ref,
+            ref_type,
+            uploader=uploader,
+            local_path=local_path,
+            dashscope_temp_url_resolver=dashscope_temp_url_resolver,
+        )
+    if mode == "kling_vendor_base64_image":
+        return _resolve_vendor_kling_image(ref, ref_type, local_path=local_path)
+    if mode.startswith("vidu_vendor_") or mode.startswith("kling_vendor_"):
+        provider_label = "Vidu" if mode.startswith("vidu_vendor_") else "Kling"
+        return _resolve_vendor_url_mode(
+            ref,
+            ref_type,
+            uploader=uploader,
+            local_path=local_path,
+            provider_label=provider_label,
+            modality=normalized_modality,
+        )
+
+    raise ValueError(
+        f"Unsupported provider media input mode '{mode}' for model '{model_name}' "
+        f"(backend={resolved_backend}, modality={normalized_modality})."
+    )
+
+
+def resolve_media_inputs(
+    refs: Sequence[str],
+    *,
+    model_name: str,
+    modality: str,
+    backend: Optional[str] = None,
+    uploader=None,
+    registry: Optional[ProviderRegistry] = None,
+    project_root: Optional[str] = None,
+    oss_base_path: Optional[str] = None,
+    dashscope_temp_url_resolver: Optional[Callable[[str], str]] = None,
+) -> List[ResolvedMediaInput]:
+    return [
+        resolve_media_input(
+            ref,
+            model_name=model_name,
+            modality=modality,
+            backend=backend,
+            uploader=uploader,
+            registry=registry,
+            project_root=project_root,
+            oss_base_path=oss_base_path,
+            dashscope_temp_url_resolver=dashscope_temp_url_resolver,
+        )
+        for ref in list(refs)
+    ]

--- a/src/utils/provider_media.py
+++ b/src/utils/provider_media.py
@@ -274,8 +274,17 @@ def resolve_media_input(
         )
     if mode == "kling_vendor_base64_image":
         return _resolve_vendor_kling_image(ref, ref_type, local_path=local_path)
-    if mode.startswith("vidu_vendor_") or mode.startswith("kling_vendor_"):
-        provider_label = "Vidu" if mode.startswith("vidu_vendor_") else "Kling"
+    if (
+        mode.startswith("vidu_vendor_")
+        or mode.startswith("kling_vendor_")
+        or mode.startswith("pixverse_vendor_")
+    ):
+        if mode.startswith("vidu_vendor_"):
+            provider_label = "Vidu"
+        elif mode.startswith("kling_vendor_"):
+            provider_label = "Kling"
+        else:
+            provider_label = "Pixverse"
         return _resolve_vendor_url_mode(
             ref,
             ref_type,

--- a/src/utils/provider_registry.py
+++ b/src/utils/provider_registry.py
@@ -1,0 +1,130 @@
+import os
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Optional, Sequence, Tuple
+
+
+SUPPORTED_PROVIDER_BACKENDS = ("dashscope", "vendor")
+
+
+@dataclass(frozen=True)
+class ProviderFamilyConfig:
+    model_family: str
+    backend_default: str = "dashscope"
+    backend_env_key: Optional[str] = None
+    credential_sources: Dict[str, Tuple[str, ...]] = field(default_factory=dict)
+    supported_modalities: Tuple[str, ...] = field(default_factory=tuple)
+    image_input_mode: Dict[str, str] = field(default_factory=dict)
+    audio_input_mode: Dict[str, str] = field(default_factory=dict)
+    reference_video_input_mode: Dict[str, str] = field(default_factory=dict)
+
+
+class ProviderRegistry:
+    """Data-driven provider routing registry keyed by model family prefix."""
+
+    def __init__(self, families: Optional[Sequence[ProviderFamilyConfig]] = None):
+        self._families: Dict[str, ProviderFamilyConfig] = {}
+        for family in families or ():
+            self.register_family(family)
+
+    def register_family(self, config: ProviderFamilyConfig) -> None:
+        family = (config.model_family or "").strip().lower()
+        if not family:
+            raise ValueError("model_family cannot be empty")
+        if config.backend_default not in SUPPORTED_PROVIDER_BACKENDS:
+            raise ValueError(f"Unsupported backend_default: {config.backend_default}")
+        self._families[family] = config
+
+    def get_family_config(self, model_name: str) -> ProviderFamilyConfig:
+        normalized = (model_name or "").strip().lower()
+        if not normalized:
+            raise ValueError("model_name cannot be empty")
+
+        for family in sorted(self._families.keys(), key=len, reverse=True):
+            if normalized.startswith(family):
+                return self._families[family]
+        raise KeyError(f"No provider family registered for model '{model_name}'")
+
+    def resolve_backend(self, model_name: str, env: Optional[Mapping[str, str]] = None) -> str:
+        family = self.get_family_config(model_name)
+        mode = ""
+        if family.backend_env_key:
+            env_mapping = env if env is not None else os.environ
+            mode = (env_mapping.get(family.backend_env_key) or "").strip().lower()
+
+        if mode in SUPPORTED_PROVIDER_BACKENDS:
+            return mode
+        return family.backend_default
+
+
+DEFAULT_PROVIDER_FAMILIES: Tuple[ProviderFamilyConfig, ...] = (
+    ProviderFamilyConfig(
+        model_family="wan2.6-",
+        backend_default="dashscope",
+        credential_sources={
+            "dashscope": ("DASHSCOPE_API_KEY",),
+        },
+        supported_modalities=("t2i", "i2i", "i2v", "r2v"),
+        image_input_mode={
+            "dashscope": "dashscope_multimodal_message",
+        },
+        audio_input_mode={
+            "dashscope": "dashscope_temp_file_url",
+        },
+        reference_video_input_mode={
+            "dashscope": "dashscope_temp_file_url",
+        },
+    ),
+    ProviderFamilyConfig(
+        model_family="kling-",
+        backend_default="dashscope",
+        backend_env_key="KLING_PROVIDER_MODE",
+        credential_sources={
+            "dashscope": ("DASHSCOPE_API_KEY",),
+            "vendor": ("KLING_ACCESS_KEY", "KLING_SECRET_KEY"),
+        },
+        supported_modalities=("t2v", "i2v"),
+        image_input_mode={
+            "dashscope": "dashscope_image_to_video",
+            "vendor": "kling_vendor_base64_image",
+        },
+        audio_input_mode={
+            "dashscope": "dashscope_temp_file_url",
+            "vendor": "kling_vendor_audio_url",
+        },
+        reference_video_input_mode={
+            "dashscope": "dashscope_temp_file_url",
+            "vendor": "kling_vendor_video_url",
+        },
+    ),
+    ProviderFamilyConfig(
+        model_family="vidu",
+        backend_default="dashscope",
+        backend_env_key="VIDU_PROVIDER_MODE",
+        credential_sources={
+            "dashscope": ("DASHSCOPE_API_KEY",),
+            "vendor": ("VIDU_API_KEY",),
+        },
+        supported_modalities=("t2v", "i2v"),
+        image_input_mode={
+            "dashscope": "dashscope_image_to_video",
+            "vendor": "vidu_vendor_image_url",
+        },
+        audio_input_mode={
+            "dashscope": "dashscope_temp_file_url",
+            "vendor": "vidu_vendor_audio_url",
+        },
+        reference_video_input_mode={
+            "dashscope": "dashscope_temp_file_url",
+            "vendor": "vidu_vendor_video_url",
+        },
+    ),
+)
+
+
+def get_default_provider_registry() -> ProviderRegistry:
+    return ProviderRegistry(DEFAULT_PROVIDER_FAMILIES)
+
+
+def resolve_provider_backend(model_name: str, env: Optional[Mapping[str, str]] = None) -> str:
+    return get_default_provider_registry().resolve_backend(model_name=model_name, env=env)
+

--- a/src/utils/provider_registry.py
+++ b/src/utils/provider_registry.py
@@ -1,12 +1,12 @@
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Dict, Mapping, Optional, Sequence, Tuple
 
 
 SUPPORTED_PROVIDER_BACKENDS = ("dashscope", "vendor")
 
 
-@dataclass(frozen=True)
+@dataclass
 class ProviderFamilyConfig:
     model_family: str
     backend_default: str = "dashscope"
@@ -30,9 +30,14 @@ class ProviderRegistry:
         family = (config.model_family or "").strip().lower()
         if not family:
             raise ValueError("model_family cannot be empty")
-        if config.backend_default not in SUPPORTED_PROVIDER_BACKENDS:
+        backend_default = (config.backend_default or "").strip().lower()
+        if backend_default not in SUPPORTED_PROVIDER_BACKENDS:
             raise ValueError(f"Unsupported backend_default: {config.backend_default}")
-        self._families[family] = config
+        self._families[family] = replace(
+            config,
+            model_family=family,
+            backend_default=backend_default,
+        )
 
     def get_family_config(self, model_name: str) -> ProviderFamilyConfig:
         normalized = (model_name or "").strip().lower()
@@ -127,4 +132,3 @@ def get_default_provider_registry() -> ProviderRegistry:
 
 def resolve_provider_backend(model_name: str, env: Optional[Mapping[str, str]] = None) -> str:
     return get_default_provider_registry().resolve_backend(model_name=model_name, env=env)
-

--- a/src/utils/provider_registry.py
+++ b/src/utils/provider_registry.py
@@ -123,6 +123,28 @@ DEFAULT_PROVIDER_FAMILIES: Tuple[ProviderFamilyConfig, ...] = (
             "vendor": "vidu_vendor_video_url",
         },
     ),
+    ProviderFamilyConfig(
+        model_family="pixverse-",
+        backend_default="dashscope",
+        backend_env_key="PIXVERSE_PROVIDER_MODE",
+        credential_sources={
+            "dashscope": ("DASHSCOPE_API_KEY",),
+            "vendor": ("PIXVERSE_API_KEY",),
+        },
+        supported_modalities=("t2v", "i2v"),
+        image_input_mode={
+            "dashscope": "dashscope_image_to_video",
+            "vendor": "pixverse_vendor_image_url",
+        },
+        audio_input_mode={
+            "dashscope": "dashscope_temp_file_url",
+            "vendor": "pixverse_vendor_audio_url",
+        },
+        reference_video_input_mode={
+            "dashscope": "dashscope_temp_file_url",
+            "vendor": "pixverse_vendor_video_url",
+        },
+    ),
 )
 
 

--- a/tests/test_image_provider_media.py
+++ b/tests/test_image_provider_media.py
@@ -1,0 +1,87 @@
+import base64
+
+from src.models.image import WanxImageModel
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+"
+    "X2VINQAAAABJRU5ErkJggg=="
+)
+
+
+class FakeUploaderConfigured:
+    def __init__(self):
+        self.is_configured = True
+
+    def sign_url_for_api(self, object_key: str):
+        return f"https://oss.example/{object_key}"
+
+
+class FakeUploaderNoOss:
+    def __init__(self):
+        self.is_configured = False
+
+
+class TestImageProviderMediaResolverIntegration:
+    def test_wan26_reference_object_key_uses_signed_url_when_oss_configured(self, monkeypatch):
+        monkeypatch.setattr("src.models.image.OSSImageUploader", FakeUploaderConfigured)
+
+        model = WanxImageModel({"params": {"i2i_model_name": "wan2.6-image"}})
+        resolved = model._resolve_wan26_reference_image("lumenx/temp/ref.png")
+
+        assert resolved == "https://oss.example/lumenx/temp/ref.png"
+
+    def test_wan26_reference_remote_url_pass_through(self, monkeypatch):
+        monkeypatch.setattr("src.models.image.OSSImageUploader", FakeUploaderNoOss)
+
+        model = WanxImageModel({"params": {"i2i_model_name": "wan2.6-image"}})
+        remote_ref = "https://example.com/ref.png"
+
+        resolved = model._resolve_wan26_reference_image(remote_ref)
+
+        assert resolved == remote_ref
+
+    def test_wan26_reference_local_without_oss_uses_data_uri(self, monkeypatch, tmp_path):
+        ref_path = tmp_path / "reference.png"
+        ref_path.write_bytes(base64.b64decode(PNG_1X1_BASE64))
+        monkeypatch.setattr("src.models.image.OSSImageUploader", FakeUploaderNoOss)
+
+        model = WanxImageModel({"params": {"i2i_model_name": "wan2.6-image"}})
+        resolved = model._resolve_wan26_reference_image(str(ref_path))
+
+        assert resolved.startswith("data:image/png;base64,")
+
+    def test_backend_selection_falls_back_to_dashscope_for_unknown_family(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        class FakeResolved:
+            value = "https://example.com/future-ref.png"
+
+        def fake_resolve_backend(_):
+            raise KeyError("unknown family")
+
+        def fake_resolve_media_input(
+            ref, *, model_name, modality, backend, uploader, **kwargs
+        ):
+            captured["ref"] = ref
+            captured["model_name"] = model_name
+            captured["modality"] = modality
+            captured["backend"] = backend
+            return FakeResolved()
+
+        monkeypatch.setattr("src.models.image.resolve_provider_backend", fake_resolve_backend)
+        monkeypatch.setattr("src.models.image.resolve_media_input", fake_resolve_media_input)
+        monkeypatch.setattr("src.models.image.OSSImageUploader", FakeUploaderNoOss)
+
+        model = WanxImageModel({"params": {"i2i_model_name": "wan2.6-image"}})
+        resolved = model._resolve_wan26_reference_image(
+            "https://example.com/future-ref.png",
+            model_name="future-image-model",
+        )
+
+        assert resolved == "https://example.com/future-ref.png"
+        assert captured["backend"] == "dashscope"
+        assert captured["modality"] == "image"
+        assert captured["model_name"] == "future-image-model"

--- a/tests/test_kling_provider_routing.py
+++ b/tests/test_kling_provider_routing.py
@@ -1,0 +1,175 @@
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.apps.comic_gen.models import VideoTask
+from src.apps.comic_gen.pipeline import ComicGenPipeline
+from src.models.kling import KlingModel
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+"
+    "X2VINQAAAABJRU5ErkJggg=="
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload=None, content=b""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.content = content
+        self.text = str(self._payload)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}: {self.text}")
+
+    def json(self):
+        return self._payload
+
+
+def _build_pipeline(task: VideoTask, wanx_model) -> ComicGenPipeline:
+    pipeline = ComicGenPipeline.__new__(ComicGenPipeline)
+    script = SimpleNamespace(
+        id=task.project_id,
+        video_tasks=[task],
+        characters=[],
+        scenes=[],
+        props=[],
+        updated_at=0,
+    )
+    pipeline.scripts = {task.project_id: script}
+    pipeline._save_data = lambda: None
+    pipeline._download_temp_image = lambda _: "/tmp/downloaded-kling.png"
+    pipeline._kling_model = None
+    pipeline._vidu_model = None
+    pipeline.video_generator = SimpleNamespace(model=wanx_model)
+    pipeline.get_script = lambda script_id: pipeline.scripts.get(script_id)
+    return pipeline
+
+
+def _write_output_png(rel_path: str) -> str:
+    file_path = Path("output") / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(base64.b64decode(PNG_1X1_BASE64))
+    return str(file_path.resolve())
+
+
+def test_pipeline_routes_kling_vendor_mode_to_vendor_adapter(monkeypatch):
+    monkeypatch.setenv("KLING_PROVIDER_MODE", "vendor")
+
+    task = VideoTask(
+        id="task-kling-vendor",
+        project_id="script-1",
+        image_url="https://example.com/ref.png",
+        prompt="demo",
+        model="kling-v1",
+    )
+
+    calls = {}
+
+    class FakeKlingModel:
+        def __init__(self, config):
+            calls["init_config"] = config
+
+        def generate(self, **kwargs):
+            calls["vendor_kwargs"] = kwargs
+            return kwargs["output_path"], 0.0
+
+    class FakeWanxModel:
+        def generate(self, **kwargs):
+            calls["wanx_kwargs"] = kwargs
+            raise AssertionError("DashScope path should not be used in vendor mode")
+
+    monkeypatch.setattr("src.models.kling.KlingModel", FakeKlingModel)
+
+    pipeline = _build_pipeline(task, FakeWanxModel())
+    pipeline.process_video_task("script-1", "task-kling-vendor")
+
+    assert "vendor_kwargs" in calls
+    assert "wanx_kwargs" not in calls
+    assert calls["vendor_kwargs"]["model"] == "kling-v1"
+    assert calls["vendor_kwargs"]["img_path"] == "/tmp/downloaded-kling.png"
+    assert task.status == "completed"
+
+
+def test_pipeline_routes_kling_dashscope_mode_to_wanx_without_vendor_credentials(monkeypatch):
+    monkeypatch.setenv("KLING_PROVIDER_MODE", "dashscope")
+    monkeypatch.delenv("KLING_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("KLING_SECRET_KEY", raising=False)
+
+    task = VideoTask(
+        id="task-kling-dashscope",
+        project_id="script-1",
+        image_url="https://example.com/ref.png",
+        prompt="demo",
+        model="kling-v1",
+    )
+
+    calls = {}
+
+    class FakeKlingModel:
+        def __init__(self, config):
+            calls["vendor_init"] = config
+
+        def generate(self, **kwargs):
+            calls["vendor_kwargs"] = kwargs
+            raise AssertionError("Vendor adapter should not be used in dashscope mode")
+
+    class FakeWanxModel:
+        def generate(self, **kwargs):
+            calls["wanx_kwargs"] = kwargs
+            return kwargs["output_path"], 0.0
+
+    monkeypatch.setattr("src.models.kling.KlingModel", FakeKlingModel)
+
+    pipeline = _build_pipeline(task, FakeWanxModel())
+    pipeline.process_video_task("script-1", "task-kling-dashscope")
+
+    assert "wanx_kwargs" in calls
+    assert "vendor_kwargs" not in calls
+    assert calls["wanx_kwargs"]["model"] == "kling-v1"
+    assert calls["wanx_kwargs"]["img_path"] == "/tmp/downloaded-kling.png"
+    assert task.status == "completed"
+
+
+def test_vendor_kling_local_image_uses_base64_payload(monkeypatch, tmp_path):
+    captured = {}
+    local_path = _write_output_png("uploads/test_kling_vendor_ref.png")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_url"] = url
+        captured["headers"] = dict(headers or {})
+        captured["body"] = json or {}
+        return _FakeResponse(200, {"code": 0, "data": {"task_id": "kling-task-1"}})
+
+    def fake_get(url, headers=None, timeout=None):
+        if "image2video" in url or "text2video" in url:
+            return _FakeResponse(
+                200,
+                {
+                    "code": 0,
+                    "data": {
+                        "task_status": "succeed",
+                        "task_result": {"videos": [{"url": "https://example.com/out.mp4"}]},
+                    },
+                },
+            )
+        return _FakeResponse(200, content=b"video")
+
+    monkeypatch.setattr("src.models.kling.requests.post", fake_post)
+    monkeypatch.setattr("src.models.kling.requests.get", fake_get)
+    monkeypatch.setattr("src.models.kling.time.sleep", lambda _: None)
+
+    model = KlingModel({"access_key": "test-ak", "secret_key": "test-sk"})
+    out_path = str(tmp_path / "out.mp4")
+    model.generate(
+        prompt="demo",
+        output_path=out_path,
+        img_path=local_path,
+        model="kling-v1",
+    )
+
+    assert captured["submit_url"].endswith("/videos/image2video")
+    assert captured["headers"]["Authorization"].startswith("Bearer ")
+    assert captured["body"]["image"] == PNG_1X1_BASE64

--- a/tests/test_local_only_flow.py
+++ b/tests/test_local_only_flow.py
@@ -1,0 +1,153 @@
+import base64
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.apps.comic_gen.models import Character, Scene, Script, StoryboardFrame
+from src.apps.comic_gen.pipeline import ComicGenPipeline
+from src.models.wanx import WanxModel
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+"
+    "X2VINQAAAABJRU5ErkJggg=="
+)
+
+
+def _write_output_png(rel_path: str) -> str:
+    file_path = Path("output") / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(base64.b64decode(PNG_1X1_BASE64))
+    return str(file_path)
+
+
+def _build_pipeline(script: Script, wanx_model: WanxModel) -> ComicGenPipeline:
+    pipeline = ComicGenPipeline.__new__(ComicGenPipeline)
+    pipeline.scripts = {script.id: script}
+    pipeline._save_data = lambda: None
+    pipeline._kling_model = None
+    pipeline._vidu_model = None
+    pipeline.video_generator = SimpleNamespace(model=wanx_model)
+    pipeline.get_script = lambda script_id: pipeline.scripts.get(script_id)
+    return pipeline
+
+
+def test_local_only_pipeline_flow_without_oss(monkeypatch):
+    """
+    End-to-end backend check for local-only mode:
+    - local uploaded/generated/storyboard refs stay as stable project refs
+    - video task snapshots local input under output/video_inputs
+    - DashScope I2V media prep works without OSS via temp oss:// URL + resolve header
+    """
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+    for key in (
+        "ALIBABA_CLOUD_ACCESS_KEY_ID",
+        "ALIBABA_CLOUD_ACCESS_KEY_SECRET",
+        "OSS_BUCKET_NAME",
+        "OSS_ENDPOINT",
+        "KLING_ACCESS_KEY",
+        "KLING_SECRET_KEY",
+        "VIDU_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    _write_output_png("uploads/local_only_uploaded.png")
+    _write_output_png("assets/scenes/local_only_generated.png")
+    _write_output_png("storyboard/local_only_frame.png")
+
+    now = time.time()
+    character = Character(
+        id="char-local",
+        name="Local Hero",
+        description="A character from local-only flow",
+        image_url="uploads/local_only_uploaded.png",
+    )
+    scene = Scene(
+        id="scene-local",
+        name="Local Scene",
+        description="A scene generated in local-only flow",
+        image_url="assets/scenes/local_only_generated.png",
+    )
+    frame = StoryboardFrame(
+        id="frame-local",
+        scene_id=scene.id,
+        character_ids=[character.id],
+        prop_ids=[],
+        rendered_image_url="storyboard/local_only_frame.png",
+    )
+    script = Script(
+        id="script-local-only",
+        title="Local-Only",
+        original_text="demo",
+        characters=[character],
+        scenes=[scene],
+        frames=[frame],
+        created_at=now,
+        updated_at=now,
+    )
+
+    captured = {}
+
+    wanx_model = WanxModel({"params": {}})
+
+    def fake_create_dashscope_temp_url(local_path: str, model_name: str) -> str:
+        captured["temp_local_path"] = local_path
+        captured["temp_model_name"] = model_name
+        return "oss://dashscope-temp/local-only/frame.png"
+
+    def fake_generate_wan_i2v_http(
+        *,
+        prompt: str,
+        img_url: str,
+        model_name: str = "wan2.6-i2v",
+        resolution: str = "720P",
+        duration: int = 5,
+        prompt_extend: bool = True,
+        negative_prompt: str = None,
+        audio_url: str = None,
+        watermark: bool = False,
+        seed: int = None,
+        shot_type: str = "single",
+        extra_headers=None,
+    ) -> str:
+        captured["img_url"] = img_url
+        captured["model_name"] = model_name
+        captured["headers"] = dict(extra_headers or {})
+        return "https://example.com/local-only-video.mp4"
+
+    def fake_download_video(_url: str, output_path: str):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_bytes(b"video")
+
+    monkeypatch.setattr(wanx_model, "_create_dashscope_temp_url", fake_create_dashscope_temp_url)
+    monkeypatch.setattr(wanx_model, "_generate_wan_i2v_http", fake_generate_wan_i2v_http)
+    monkeypatch.setattr(wanx_model, "_download_video", fake_download_video)
+
+    pipeline = _build_pipeline(script, wanx_model)
+
+    _, task_id = pipeline.create_video_task(
+        script_id=script.id,
+        image_url=frame.rendered_image_url,
+        prompt="Pan and zoom on the character",
+        model="wan2.6-i2v",
+    )
+    task = next(t for t in script.video_tasks if t.id == task_id)
+
+    assert task.image_url.startswith("video_inputs/")
+    assert (Path("output") / task.image_url).exists()
+
+    pipeline.process_video_task(script.id, task_id)
+
+    assert task.status == "completed"
+    assert task.video_url.startswith("video/video_")
+
+    assert captured["img_url"] == "oss://dashscope-temp/local-only/frame.png"
+    assert captured["model_name"] == "wan2.6-i2v"
+    assert captured["temp_model_name"] == "wan2.6-i2v"
+    assert captured["headers"]["X-DashScope-OssResourceResolve"] == "enable"
+    assert captured["temp_local_path"].startswith(str(Path.cwd()))
+
+    # Stable project refs remain local refs; request-side transforms are not persisted.
+    assert script.characters[0].image_url == "uploads/local_only_uploaded.png"
+    assert script.scenes[0].image_url == "assets/scenes/local_only_generated.png"
+    assert script.frames[0].rendered_image_url == "storyboard/local_only_frame.png"

--- a/tests/test_media_refs.py
+++ b/tests/test_media_refs.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from src.utils.media_refs import (
+    classify_media_ref,
+    is_remote_media_ref,
+    is_stable_project_media_ref,
+    resolve_local_media_path,
+)
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_classify_local_relative_path():
+    assert classify_media_ref("uploads/foo.png") == "local_path"
+
+
+def test_classify_local_absolute_path_under_output():
+    abs_path = str(_project_root() / "output" / "uploads" / "foo.png")
+    assert classify_media_ref(abs_path) == "local_path"
+
+
+def test_classify_oss_object_key():
+    assert classify_media_ref("lumenx/project_1/assets/foo.png") == "object_key"
+
+
+def test_classify_remote_url():
+    assert classify_media_ref("https://example.com/a.png") == "remote_url"
+    assert is_remote_media_ref("http://example.com/a.png")
+    assert is_remote_media_ref("blob:https://example.com/abc")
+
+
+def test_classify_data_uri_is_not_stable_storage():
+    value = "data:image/png;base64,AAAA"
+    assert classify_media_ref(value) == "data_uri"
+    assert not is_stable_project_media_ref(value)
+
+
+def test_resolve_local_relative_path_to_absolute():
+    resolved = resolve_local_media_path("uploads/foo.png")
+    expected = str((_project_root() / "output" / "uploads" / "foo.png").resolve())
+    assert resolved == expected
+
+
+def test_resolve_local_absolute_path_under_output():
+    input_path = str(_project_root() / "output" / "video" / "clip.mp4")
+    expected = str((_project_root() / "output" / "video" / "clip.mp4").resolve())
+    assert resolve_local_media_path(input_path) == expected

--- a/tests/test_media_refs.py
+++ b/tests/test_media_refs.py
@@ -21,14 +21,19 @@ def test_classify_local_absolute_path_under_output():
     assert classify_media_ref(abs_path) == "local_path"
 
 
-def test_classify_oss_object_key():
-    assert classify_media_ref("lumenx/project_1/assets/foo.png") == "object_key"
+def test_classify_oss_object_key(monkeypatch):
+    monkeypatch.setenv("OSS_BASE_PATH", "stable-test-base")
+    assert (
+        classify_media_ref("stable-test-base/project_1/assets/foo.png")
+        == "object_key"
+    )
 
 
 def test_classify_remote_url():
     assert classify_media_ref("https://example.com/a.png") == "remote_url"
     assert is_remote_media_ref("http://example.com/a.png")
     assert is_remote_media_ref("blob:https://example.com/abc")
+    assert not is_stable_project_media_ref("blob:https://example.com/abc")
 
 
 def test_classify_data_uri_is_not_stable_storage():

--- a/tests/test_provider_media.py
+++ b/tests/test_provider_media.py
@@ -1,0 +1,169 @@
+import base64
+from pathlib import Path
+
+import pytest
+
+from src.utils.provider_media import (
+    RESOLVE_HEADER_DASHSCOPE_OSS_RESOURCE,
+    resolve_media_input,
+    resolve_media_inputs,
+)
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+"
+    "X2VINQAAAABJRU5ErkJggg=="
+)
+
+
+class FakeUploader:
+    def __init__(self, configured: bool):
+        self.is_configured = configured
+        self.uploaded_paths = []
+
+    def upload_file(self, local_path: str, sub_path: str = "", custom_filename=None):
+        if not self.is_configured:
+            return None
+        self.uploaded_paths.append((local_path, sub_path))
+        filename = custom_filename or Path(local_path).name
+        return f"lumenx/{sub_path.strip('/')}/{filename}".replace("//", "/")
+
+    def sign_url_for_api(self, object_key: str):
+        return f"https://oss.example/{object_key}"
+
+
+def _write_output_png(project_root: Path, rel_path: str) -> Path:
+    output_root = project_root / "output"
+    file_path = output_root / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(base64.b64decode(PNG_1X1_BASE64))
+    return file_path
+
+
+def test_dashscope_image_local_without_oss_uses_data_uri(tmp_path):
+    _write_output_png(tmp_path, "uploads/ref.png")
+    ref = "uploads/ref.png"
+    uploader = FakeUploader(configured=False)
+
+    resolved = resolve_media_input(
+        ref,
+        model_name="wan2.6-image",
+        backend="dashscope",
+        modality="image",
+        uploader=uploader,
+        project_root=str(tmp_path),
+    )
+
+    assert resolved.value.startswith("data:image/png;base64,")
+    assert resolved.headers == {}
+    assert ref == "uploads/ref.png"
+
+
+@pytest.mark.parametrize("modality", ["audio", "video", "reference_video"])
+def test_dashscope_non_image_local_without_oss_uses_temp_url_and_header(tmp_path, modality):
+    _write_output_png(tmp_path, "video/ref.mp4")
+    uploader = FakeUploader(configured=False)
+
+    def fake_temp_url_resolver(local_path: str) -> str:
+        assert local_path.endswith("output/video/ref.mp4")
+        return "oss://dashscope-temp/session-file-001"
+
+    resolved = resolve_media_input(
+        "video/ref.mp4",
+        model_name="wan2.6-i2v",
+        backend="dashscope",
+        modality=modality,
+        uploader=uploader,
+        project_root=str(tmp_path),
+        dashscope_temp_url_resolver=fake_temp_url_resolver,
+    )
+
+    assert resolved.value == "oss://dashscope-temp/session-file-001"
+    assert resolved.headers.get(RESOLVE_HEADER_DASHSCOPE_OSS_RESOURCE) == "enable"
+
+
+def test_dashscope_local_uses_oss_signed_url_when_configured(tmp_path):
+    _write_output_png(tmp_path, "uploads/ref.png")
+    uploader = FakeUploader(configured=True)
+
+    resolved = resolve_media_input(
+        "uploads/ref.png",
+        model_name="wan2.6-image",
+        backend="dashscope",
+        modality="image",
+        uploader=uploader,
+        project_root=str(tmp_path),
+    )
+
+    assert resolved.value.startswith("https://oss.example/lumenx/temp/provider_media/")
+    assert resolved.headers == {}
+    assert uploader.uploaded_paths
+
+
+def test_vendor_kling_image_local_uses_plain_base64(tmp_path):
+    _write_output_png(tmp_path, "uploads/ref.png")
+    uploader = FakeUploader(configured=False)
+
+    resolved = resolve_media_input(
+        "uploads/ref.png",
+        model_name="kling-v1",
+        backend="vendor",
+        modality="image",
+        uploader=uploader,
+        project_root=str(tmp_path),
+    )
+
+    assert not resolved.value.startswith("data:")
+    assert resolved.value == PNG_1X1_BASE64
+    assert resolved.headers == {}
+
+
+def test_vendor_vidu_image_local_requires_url_capability(tmp_path):
+    _write_output_png(tmp_path, "uploads/ref.png")
+    uploader = FakeUploader(configured=False)
+
+    with pytest.raises(ValueError, match="requires a URL-compatible media source"):
+        resolve_media_input(
+            "uploads/ref.png",
+            model_name="vidu-q3",
+            backend="vendor",
+            modality="image",
+            uploader=uploader,
+            project_root=str(tmp_path),
+        )
+
+
+def test_vendor_vidu_image_local_with_oss_uses_signed_url(tmp_path):
+    _write_output_png(tmp_path, "uploads/ref.png")
+    uploader = FakeUploader(configured=True)
+
+    resolved = resolve_media_input(
+        "uploads/ref.png",
+        model_name="vidu-q3",
+        backend="vendor",
+        modality="image",
+        uploader=uploader,
+        project_root=str(tmp_path),
+    )
+
+    assert resolved.value.startswith("https://oss.example/lumenx/temp/provider_media/")
+
+
+def test_resolver_does_not_mutate_input_refs(tmp_path):
+    _write_output_png(tmp_path, "uploads/ref.png")
+    uploader = FakeUploader(configured=False)
+    refs = ["uploads/ref.png"]
+    original = list(refs)
+
+    resolved = resolve_media_inputs(
+        refs,
+        model_name="wan2.6-image",
+        backend="dashscope",
+        modality="image",
+        uploader=uploader,
+        project_root=str(tmp_path),
+    )
+
+    assert refs == original
+    assert len(resolved) == 1
+    assert resolved[0].value.startswith("data:image/png;base64,")

--- a/tests/test_provider_media.py
+++ b/tests/test_provider_media.py
@@ -82,6 +82,24 @@ def test_dashscope_non_image_local_without_oss_uses_temp_url_and_header(tmp_path
     assert resolved.headers.get(RESOLVE_HEADER_DASHSCOPE_OSS_RESOURCE) == "enable"
 
 
+def test_dashscope_non_image_local_without_oss_and_without_temp_resolver_fails_fast(tmp_path):
+    _write_output_png(tmp_path, "video/ref.mp4")
+    uploader = FakeUploader(configured=False)
+
+    with pytest.raises(
+        ValueError,
+        match="requires OSS or a dashscope_temp_url_resolver",
+    ):
+        resolve_media_input(
+            "video/ref.mp4",
+            model_name="wan2.6-i2v",
+            backend="dashscope",
+            modality="audio",
+            uploader=uploader,
+            project_root=str(tmp_path),
+        )
+
+
 def test_dashscope_local_uses_oss_signed_url_when_configured(tmp_path):
     _write_output_png(tmp_path, "uploads/ref.png")
     uploader = FakeUploader(configured=True)

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,89 @@
+from src.apps.comic_gen.models import ProviderBackend, ProviderRoutingConfig
+from src.utils.provider_registry import ProviderFamilyConfig, ProviderRegistry, get_default_provider_registry
+
+
+class TestProviderRegistryRouting:
+    def test_wan26_models_route_to_dashscope(self):
+        registry = get_default_provider_registry()
+
+        assert registry.resolve_backend("wan2.6-t2i") == "dashscope"
+        assert registry.resolve_backend("wan2.6-image") == "dashscope"
+        assert registry.resolve_backend("wan2.6-i2v") == "dashscope"
+
+    def test_kling_defaults_to_dashscope_when_mode_is_unset(self):
+        registry = get_default_provider_registry()
+
+        assert registry.resolve_backend("kling-v1") == "dashscope"
+        assert registry.resolve_backend("kling-v1", env={"KLING_PROVIDER_MODE": ""}) == "dashscope"
+
+    def test_vidu_defaults_to_dashscope_when_mode_is_unset(self):
+        registry = get_default_provider_registry()
+
+        assert registry.resolve_backend("vidu2.0") == "dashscope"
+        assert registry.resolve_backend("vidu2.0", env={"VIDU_PROVIDER_MODE": ""}) == "dashscope"
+
+    def test_kling_and_vidu_can_route_to_vendor(self):
+        registry = get_default_provider_registry()
+        env = {
+            "KLING_PROVIDER_MODE": "vendor",
+            "VIDU_PROVIDER_MODE": "vendor",
+        }
+
+        assert registry.resolve_backend("kling-v1", env=env) == "vendor"
+        assert registry.resolve_backend("vidu2.0", env=env) == "vendor"
+
+    def test_future_pixverse_family_can_be_registered_without_resolver_changes(self):
+        registry = ProviderRegistry()
+        registry.register_family(
+            ProviderFamilyConfig(
+                model_family="pixverse-",
+                backend_default="dashscope",
+                backend_env_key="PIXVERSE_PROVIDER_MODE",
+                credential_sources={
+                    "dashscope": ("DASHSCOPE_API_KEY",),
+                    "vendor": ("PIXVERSE_API_KEY",),
+                },
+                supported_modalities=("t2v", "i2v"),
+                image_input_mode={
+                    "dashscope": "dashscope_image_input",
+                    "vendor": "pixverse_vendor_image_input",
+                },
+                audio_input_mode={
+                    "dashscope": "dashscope_temp_file_url",
+                    "vendor": "pixverse_vendor_audio_url",
+                },
+                reference_video_input_mode={
+                    "dashscope": "dashscope_temp_file_url",
+                    "vendor": "pixverse_vendor_reference_video_url",
+                },
+            )
+        )
+
+        assert registry.resolve_backend("pixverse-v4-i2v") == "dashscope"
+        assert (
+            registry.resolve_backend(
+                "pixverse-v4-i2v",
+                env={"PIXVERSE_PROVIDER_MODE": "vendor"},
+            )
+            == "vendor"
+        )
+
+
+class TestProviderRoutingConfig:
+    def test_provider_modes_default_to_dashscope(self):
+        config = ProviderRoutingConfig()
+
+        assert config.KLING_PROVIDER_MODE == ProviderBackend.DASHSCOPE
+        assert config.VIDU_PROVIDER_MODE == ProviderBackend.DASHSCOPE
+        assert config.PIXVERSE_PROVIDER_MODE == ProviderBackend.DASHSCOPE
+
+    def test_provider_modes_accept_vendor_override(self):
+        config = ProviderRoutingConfig(
+            KLING_PROVIDER_MODE="vendor",
+            VIDU_PROVIDER_MODE="vendor",
+            PIXVERSE_PROVIDER_MODE="vendor",
+        )
+
+        assert config.KLING_PROVIDER_MODE == ProviderBackend.VENDOR
+        assert config.VIDU_PROVIDER_MODE == ProviderBackend.VENDOR
+        assert config.PIXVERSE_PROVIDER_MODE == ProviderBackend.VENDOR

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -22,15 +22,29 @@ class TestProviderRegistryRouting:
         assert registry.resolve_backend("vidu2.0") == "dashscope"
         assert registry.resolve_backend("vidu2.0", env={"VIDU_PROVIDER_MODE": ""}) == "dashscope"
 
-    def test_kling_and_vidu_can_route_to_vendor(self):
+    def test_pixverse_defaults_to_dashscope_when_mode_is_unset(self):
+        registry = get_default_provider_registry()
+
+        assert registry.resolve_backend("pixverse-v4-i2v") == "dashscope"
+        assert (
+            registry.resolve_backend(
+                "pixverse-v4-i2v",
+                env={"PIXVERSE_PROVIDER_MODE": ""},
+            )
+            == "dashscope"
+        )
+
+    def test_kling_vidu_and_pixverse_can_route_to_vendor(self):
         registry = get_default_provider_registry()
         env = {
             "KLING_PROVIDER_MODE": "vendor",
             "VIDU_PROVIDER_MODE": "vendor",
+            "PIXVERSE_PROVIDER_MODE": "vendor",
         }
 
         assert registry.resolve_backend("kling-v1", env=env) == "vendor"
         assert registry.resolve_backend("vidu2.0", env=env) == "vendor"
+        assert registry.resolve_backend("pixverse-v4-i2v", env=env) == "vendor"
 
     def test_invalid_provider_mode_falls_back_to_default_backend(self):
         registry = get_default_provider_registry()

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -32,6 +32,12 @@ class TestProviderRegistryRouting:
         assert registry.resolve_backend("kling-v1", env=env) == "vendor"
         assert registry.resolve_backend("vidu2.0", env=env) == "vendor"
 
+    def test_invalid_provider_mode_falls_back_to_default_backend(self):
+        registry = get_default_provider_registry()
+        env = {"KLING_PROVIDER_MODE": "not-a-valid-backend"}
+
+        assert registry.resolve_backend("kling-v1", env=env) == "dashscope"
+
     def test_future_pixverse_family_can_be_registered_without_resolver_changes(self):
         registry = ProviderRegistry()
         registry.register_family(

--- a/tests/test_vidu_provider_routing.py
+++ b/tests/test_vidu_provider_routing.py
@@ -1,0 +1,197 @@
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.apps.comic_gen.models import VideoTask
+from src.apps.comic_gen.pipeline import ComicGenPipeline
+from src.models.vidu import ViduModel
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+"
+    "X2VINQAAAABJRU5ErkJggg=="
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload=None, content=b""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.content = content
+        self.text = str(self._payload)
+
+    def json(self):
+        return self._payload
+
+
+def _build_pipeline(task: VideoTask, wanx_model) -> ComicGenPipeline:
+    pipeline = ComicGenPipeline.__new__(ComicGenPipeline)
+    script = SimpleNamespace(
+        id=task.project_id,
+        video_tasks=[task],
+        characters=[],
+        scenes=[],
+        props=[],
+        updated_at=0,
+    )
+    pipeline.scripts = {task.project_id: script}
+    pipeline._save_data = lambda: None
+    pipeline._download_temp_image = lambda _: "/tmp/downloaded-vidu.png"
+    pipeline._kling_model = None
+    pipeline._vidu_model = None
+    pipeline.video_generator = SimpleNamespace(model=wanx_model)
+    pipeline.get_script = lambda script_id: pipeline.scripts.get(script_id)
+    return pipeline
+
+
+def _write_output_png(rel_path: str) -> str:
+    file_path = Path("output") / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(base64.b64decode(PNG_1X1_BASE64))
+    return str(file_path.resolve())
+
+
+def test_pipeline_routes_vidu_vendor_mode_to_vendor_adapter(monkeypatch):
+    monkeypatch.setenv("VIDU_PROVIDER_MODE", "vendor")
+
+    task = VideoTask(
+        id="task-vidu-vendor",
+        project_id="script-1",
+        image_url="https://example.com/ref.png",
+        prompt="demo",
+        model="viduq3-pro",
+    )
+
+    calls = {}
+
+    class FakeViduModel:
+        def __init__(self, config):
+            calls["init_config"] = config
+
+        def generate(self, **kwargs):
+            calls["vendor_kwargs"] = kwargs
+            return kwargs["output_path"], 0.0
+
+    class FakeWanxModel:
+        def generate(self, **kwargs):
+            calls["wanx_kwargs"] = kwargs
+            raise AssertionError("DashScope path should not be used in vendor mode")
+
+    monkeypatch.setattr("src.models.vidu.ViduModel", FakeViduModel)
+
+    pipeline = _build_pipeline(task, FakeWanxModel())
+    pipeline.process_video_task("script-1", "task-vidu-vendor")
+
+    assert "vendor_kwargs" in calls
+    assert "wanx_kwargs" not in calls
+    assert calls["vendor_kwargs"]["model"] == "viduq3-pro"
+    assert calls["vendor_kwargs"]["img_path"] == "/tmp/downloaded-vidu.png"
+    assert task.status == "completed"
+
+
+def test_pipeline_routes_vidu_dashscope_mode_to_wanx_without_vendor_credentials(monkeypatch):
+    monkeypatch.setenv("VIDU_PROVIDER_MODE", "dashscope")
+    monkeypatch.delenv("VIDU_API_KEY", raising=False)
+
+    task = VideoTask(
+        id="task-vidu-dashscope",
+        project_id="script-1",
+        image_url="https://example.com/ref.png",
+        prompt="demo",
+        model="viduq3-pro",
+    )
+
+    calls = {}
+
+    class FakeViduModel:
+        def __init__(self, config):
+            calls["vendor_init"] = config
+
+        def generate(self, **kwargs):
+            calls["vendor_kwargs"] = kwargs
+            raise AssertionError("Vendor adapter should not be used in dashscope mode")
+
+    class FakeWanxModel:
+        def generate(self, **kwargs):
+            calls["wanx_kwargs"] = kwargs
+            return kwargs["output_path"], 0.0
+
+    monkeypatch.setattr("src.models.vidu.ViduModel", FakeViduModel)
+
+    pipeline = _build_pipeline(task, FakeWanxModel())
+    pipeline.process_video_task("script-1", "task-vidu-dashscope")
+
+    assert "wanx_kwargs" in calls
+    assert "vendor_kwargs" not in calls
+    assert calls["wanx_kwargs"]["model"] == "viduq3-pro"
+    assert calls["wanx_kwargs"]["img_path"] == "/tmp/downloaded-vidu.png"
+    assert task.status == "completed"
+
+
+def test_vendor_vidu_local_image_without_oss_fails_clearly(monkeypatch, tmp_path):
+    local_path = _write_output_png("uploads/test_vidu_vendor_ref_no_oss.png")
+
+    class FakeUploader:
+        def __init__(self):
+            self.is_configured = False
+
+    monkeypatch.setattr("src.models.vidu.OSSImageUploader", FakeUploader)
+
+    model = ViduModel({"api_key": "test-key"})
+
+    with pytest.raises(ValueError, match="requires a URL-compatible media source"):
+        model.generate(
+            prompt="demo",
+            output_path=str(tmp_path / "out.mp4"),
+            img_path=local_path,
+            model="viduq3-pro",
+        )
+
+
+def test_vendor_vidu_local_image_with_oss_uses_signed_url(monkeypatch, tmp_path):
+    captured = {}
+    local_path = _write_output_png("uploads/test_vidu_vendor_ref_with_oss.png")
+
+    class FakeUploader:
+        def __init__(self):
+            self.is_configured = True
+
+        def upload_file(self, local_path, sub_path="", custom_filename=None):
+            filename = custom_filename or Path(local_path).name
+            return f"lumenx/{sub_path.strip('/')}/{filename}".replace("//", "/")
+
+        def sign_url_for_api(self, object_key):
+            return f"https://oss.example/{object_key}"
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_url"] = url
+        captured["headers"] = dict(headers or {})
+        captured["body"] = json or {}
+        return _FakeResponse(200, {"task_id": "vidu-task-1"})
+
+    def fake_get(url, headers=None, timeout=None):
+        if "tasks" in url:
+            return _FakeResponse(
+                200,
+                {"state": "success", "creations": [{"url": "https://example.com/out.mp4"}]},
+            )
+        return _FakeResponse(200, content=b"video")
+
+    monkeypatch.setattr("src.models.vidu.OSSImageUploader", FakeUploader)
+    monkeypatch.setattr("src.models.vidu.requests.post", fake_post)
+    monkeypatch.setattr("src.models.vidu.requests.get", fake_get)
+    monkeypatch.setattr("src.models.vidu.time.sleep", lambda _: None)
+
+    model = ViduModel({"api_key": "test-key"})
+    model.generate(
+        prompt="demo",
+        output_path=str(tmp_path / "out.mp4"),
+        img_path=local_path,
+        model="viduq3-pro",
+    )
+
+    assert captured["submit_url"].endswith("/img2video")
+    assert captured["headers"]["Authorization"] == "Token test-key"
+    assert captured["body"]["images"][0].startswith("https://oss.example/lumenx/")

--- a/tests/test_wanx_provider_media.py
+++ b/tests/test_wanx_provider_media.py
@@ -229,3 +229,45 @@ class TestWanxProviderMediaIntegration:
         assert captured["upload_data"]["OSSAccessKeyId"] == "ak-xyz"
         assert captured["upload_file_name"] == "wanx_temp_upload_source.png"
         assert captured["upload_file_content"] == b"img-bytes"
+
+    def test_sdk_dashscope_proxy_model_local_image_uses_resolved_image_value(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+        _install_fake_uploader(monkeypatch, configured=False)
+
+        captured = {}
+
+        def fake_generate_sdk(
+            self,
+            prompt,
+            model_name,
+            img_url=None,
+            size="1280*720",
+            duration=5,
+            prompt_extend=True,
+            negative_prompt=None,
+            audio_url=None,
+            watermark=False,
+            seed=None,
+            camera_motion=None,
+            subject_motion=None,
+        ):
+            captured["model_name"] = model_name
+            captured["img_url"] = img_url
+            return "https://example.com/out.mp4"
+
+        monkeypatch.setattr("src.models.wanx.WanxModel._generate_sdk", fake_generate_sdk)
+        monkeypatch.setattr("src.models.wanx.WanxModel._download_video", lambda self, *_: None)
+
+        img_path = _write_output_file("uploads/wanx_sdk_kling_local.png", base64.b64decode(PNG_1X1_BASE64))
+
+        model = WanxModel({"params": {}})
+        model.generate(
+            prompt="demo",
+            output_path="output/video/wanx_sdk_kling_local.mp4",
+            img_path=img_path,
+            model_name="kling-v1",
+        )
+
+        assert captured["model_name"] == "kling-v1"
+        assert captured["img_url"].startswith("data:image/")
+        assert ";base64," in captured["img_url"]

--- a/tests/test_wanx_provider_media.py
+++ b/tests/test_wanx_provider_media.py
@@ -86,12 +86,16 @@ def _install_fake_uploader(monkeypatch, configured: bool):
 
 
 class TestWanxProviderMediaIntegration:
-    def test_i2v_local_image_without_oss_uses_data_uri(self, monkeypatch):
+    def test_i2v_local_image_without_oss_uses_temp_url_and_header(self, monkeypatch):
         monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
         _install_fake_uploader(monkeypatch, configured=False)
 
         captured = {}
         _install_fake_requests(monkeypatch, captured)
+        monkeypatch.setattr(
+            "src.models.wanx.WanxModel._create_dashscope_temp_url",
+            lambda self, local_path, model_name: "oss://dashscope-temp/image-001",
+        )
 
         img_path = _write_output_file("uploads/wanx_i2v_local.png", base64.b64decode(PNG_1X1_BASE64))
 
@@ -103,7 +107,8 @@ class TestWanxProviderMediaIntegration:
             model_name="wan2.6-i2v",
         )
 
-        assert captured["create_payload"]["input"]["img_url"].startswith("data:image/png;base64,")
+        assert captured["create_payload"]["input"]["img_url"] == "oss://dashscope-temp/image-001"
+        assert captured["create_headers"]["X-DashScope-OssResourceResolve"] == "enable"
 
     def test_i2v_local_audio_without_oss_uses_temp_url_and_header(self, monkeypatch):
         monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
@@ -176,3 +181,51 @@ class TestWanxProviderMediaIntegration:
             captured["create_payload"]["input"]["img_url"]
             == "https://oss.example/lumenx/temp/i2v_input/ref.png"
         )
+
+    def test_create_dashscope_temp_url_calls_policy_and_multipart_upload(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+        local_path = _write_output_file("uploads/wanx_temp_upload_source.png", b"img-bytes")
+
+        captured = {}
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            captured["policy_url"] = url
+            captured["policy_params"] = dict(params or {})
+            captured["policy_headers"] = dict(headers or {})
+            return _FakeResponse(
+                200,
+                {
+                    "output": {
+                        "upload_host": "https://upload.example",
+                        "upload_dir": "dashscope-temp/dir",
+                        "policy": "policy-xyz",
+                        "signature": "sig-xyz",
+                        "oss_access_key_id": "ak-xyz",
+                    }
+                },
+            )
+
+        def fake_post(url, data=None, files=None, timeout=None, headers=None, json=None):
+            captured["upload_url"] = url
+            captured["upload_data"] = dict(data or {})
+            captured["upload_file_name"] = files["file"][0] if files else None
+            captured["upload_file_content"] = files["file"][1].read() if files else None
+            return _FakeResponse(204, {})
+
+        monkeypatch.setattr("src.models.wanx.requests.get", fake_get)
+        monkeypatch.setattr("src.models.wanx.requests.post", fake_post)
+
+        model = WanxModel({"params": {}})
+        resolved = model._create_dashscope_temp_url(local_path, "wan2.6-i2v")
+
+        assert resolved == "oss://dashscope-temp/dir/wanx_temp_upload_source.png"
+        assert captured["policy_url"].endswith("/api/v1/uploads")
+        assert captured["policy_params"] == {"action": "getPolicy", "model": "wan2.6-i2v"}
+        assert captured["policy_headers"]["Authorization"] == "Bearer test-key"
+        assert captured["upload_url"] == "https://upload.example"
+        assert captured["upload_data"]["key"] == "dashscope-temp/dir/wanx_temp_upload_source.png"
+        assert captured["upload_data"]["policy"] == "policy-xyz"
+        assert captured["upload_data"]["signature"] == "sig-xyz"
+        assert captured["upload_data"]["OSSAccessKeyId"] == "ak-xyz"
+        assert captured["upload_file_name"] == "wanx_temp_upload_source.png"
+        assert captured["upload_file_content"] == b"img-bytes"

--- a/tests/test_wanx_provider_media.py
+++ b/tests/test_wanx_provider_media.py
@@ -1,0 +1,178 @@
+import base64
+from pathlib import Path
+
+from src.models.wanx import WanxModel
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+"
+    "X2VINQAAAABJRU5ErkJggg=="
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+def _write_output_file(rel_path: str, raw_bytes: bytes) -> str:
+    file_path = Path("output") / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(raw_bytes)
+    return str(file_path)
+
+
+def _install_fake_requests(monkeypatch, captured):
+    def fake_post(url, headers=None, json=None, timeout=None, data=None, files=None):
+        if "video-synthesis" in url:
+            captured["create_headers"] = dict(headers or {})
+            captured["create_payload"] = json
+            return _FakeResponse(
+                200,
+                {"output": {"task_id": "task-1", "task_status": "PENDING"}},
+            )
+        # Keep compatibility with potential temp-upload POSTs if any test forgets to patch helper.
+        if data is not None and files is not None:
+            return _FakeResponse(204, {})
+        return _FakeResponse(404, {"message": "unexpected URL"})
+
+    def fake_get(url, headers=None, timeout=None, params=None):
+        if "/api/v1/tasks/" in url:
+            return _FakeResponse(
+                200,
+                {"output": {"task_status": "SUCCEEDED", "video_url": "https://example.com/out.mp4"}},
+            )
+        if "/api/v1/uploads" in url:
+            return _FakeResponse(
+                200,
+                {
+                    "output": {
+                        "upload_host": "https://upload.example",
+                        "upload_dir": "dashscope-temp/session",
+                        "policy": "policy",
+                        "signature": "sig",
+                        "oss_access_key_id": "ak",
+                    }
+                },
+            )
+        return _FakeResponse(404, {"message": "unexpected URL"})
+
+    monkeypatch.setattr("src.models.wanx.requests.post", fake_post)
+    monkeypatch.setattr("src.models.wanx.requests.get", fake_get)
+    monkeypatch.setattr("src.models.wanx.time.sleep", lambda _: None)
+    monkeypatch.setattr("src.models.wanx.WanxModel._download_video", lambda self, *_: None)
+
+
+def _install_fake_uploader(monkeypatch, configured: bool):
+    class _FakeUploader:
+        def __init__(self):
+            self.is_configured = configured
+
+        def upload_file(self, local_path, sub_path="", custom_filename=None):
+            if not self.is_configured:
+                return None
+            filename = custom_filename or Path(local_path).name
+            return f"lumenx/{sub_path.strip('/')}/{filename}".replace("//", "/")
+
+        def sign_url_for_api(self, object_key):
+            return f"https://oss.example/{object_key}"
+
+    monkeypatch.setattr("src.models.wanx.OSSImageUploader", _FakeUploader)
+
+
+class TestWanxProviderMediaIntegration:
+    def test_i2v_local_image_without_oss_uses_data_uri(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+        _install_fake_uploader(monkeypatch, configured=False)
+
+        captured = {}
+        _install_fake_requests(monkeypatch, captured)
+
+        img_path = _write_output_file("uploads/wanx_i2v_local.png", base64.b64decode(PNG_1X1_BASE64))
+
+        model = WanxModel({"params": {}})
+        model.generate(
+            prompt="demo",
+            output_path="output/video/wanx_i2v_local.mp4",
+            img_path=img_path,
+            model_name="wan2.6-i2v",
+        )
+
+        assert captured["create_payload"]["input"]["img_url"].startswith("data:image/png;base64,")
+
+    def test_i2v_local_audio_without_oss_uses_temp_url_and_header(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+        _install_fake_uploader(monkeypatch, configured=False)
+
+        captured = {}
+        _install_fake_requests(monkeypatch, captured)
+        monkeypatch.setattr(
+            "src.models.wanx.WanxModel._create_dashscope_temp_url",
+            lambda self, local_path, model_name: "oss://dashscope-temp/audio-001",
+        )
+
+        img_path = _write_output_file("uploads/wanx_i2v_audio_img.png", base64.b64decode(PNG_1X1_BASE64))
+        audio_path = _write_output_file("audio/wanx_i2v_audio.wav", b"fake-audio")
+
+        model = WanxModel({"params": {}})
+        model.generate(
+            prompt="demo",
+            output_path="output/video/wanx_i2v_audio.mp4",
+            img_path=img_path,
+            model_name="wan2.6-i2v",
+            audio_url=audio_path,
+        )
+
+        assert captured["create_payload"]["input"]["audio_url"] == "oss://dashscope-temp/audio-001"
+        assert captured["create_headers"]["X-DashScope-OssResourceResolve"] == "enable"
+
+    def test_r2v_local_reference_video_without_oss_uses_temp_url_and_header(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+        _install_fake_uploader(monkeypatch, configured=False)
+
+        captured = {}
+        _install_fake_requests(monkeypatch, captured)
+        monkeypatch.setattr(
+            "src.models.wanx.WanxModel._create_dashscope_temp_url",
+            lambda self, local_path, model_name: "oss://dashscope-temp/ref-video-001",
+        )
+
+        ref_video_path = _write_output_file("video/wanx_r2v_ref.mp4", b"fake-video")
+
+        model = WanxModel({"params": {}})
+        model.generate(
+            prompt="demo",
+            output_path="output/video/wanx_r2v.mp4",
+            model_name="wan2.6-r2v",
+            ref_video_urls=[ref_video_path],
+        )
+
+        assert captured["create_payload"]["input"]["reference_video_urls"] == [
+            "oss://dashscope-temp/ref-video-001"
+        ]
+        assert captured["create_headers"]["X-DashScope-OssResourceResolve"] == "enable"
+
+    def test_i2v_object_key_with_oss_configured_uses_signed_url(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+        _install_fake_uploader(monkeypatch, configured=True)
+
+        captured = {}
+        _install_fake_requests(monkeypatch, captured)
+
+        model = WanxModel({"params": {}})
+        model.generate(
+            prompt="demo",
+            output_path="output/video/wanx_i2v_object_key.mp4",
+            img_path="lumenx/temp/i2v_input/ref.png",
+            model_name="wan2.6-i2v",
+        )
+
+        assert (
+            captured["create_payload"]["input"]["img_url"]
+            == "https://oss.example/lumenx/temp/i2v_input/ref.png"
+        )


### PR DESCRIPTION
## 概述

这个 PR 让媒体处理流程不再强依赖 OSS，补齐了“本地优先 + 可选 OSS”的 fallback 路径，使未配置 OSS 的用户也能完成角色图、图生图、图生视频等核心链路。

同时，这个 PR 引入了 provider-aware 路由能力：默认优先走 DashScope / 百炼，在支持的场景下也允许用户显式切换到原厂 API，例如 Kling、Vidu；并为后续 Pixverse 等模型接入预留了统一路由能力。

## 主要改动

- 让 OSS 从必选依赖变为可选能力
- 增加本地优先的媒体引用与稳定媒体引用语义
- 修复 Wan 2.6 在未配置 OSS 时无法使用本地参考图的问题
- 增加 provider registry 和 provider-aware media resolver
- 默认优先走 DashScope，同时支持用户显式切换到原厂 provider
- 为 Pixverse 补齐 provider routing 配置，和前端已暴露配置保持一致
- 在前端设置页与环境配置弹窗中补充 provider mode 的可感知配置
- 拆分前端 Vitest 运行模式，区分 node 环境测试与 UI 测试，提升本地与 CI 稳定性
- 改进日志初始化逻辑，避免在受限环境或测试环境下因为用户目录不可写导致失败
- 补充并更新相关 README、手册与贡献说明

## 设计目标

本次改动的目标是建立一条完整的无 OSS fallback 路径：

- 所有媒体资产始终先保存到本地
- 如果用户配置了 OSS，则继续上传 OSS 并优先复用 OSS URL
- 如果用户没有配置 OSS，则根据 provider 能力自动选择可用的本地 fallback 方式
- 对于 DashScope 代理模型，优先走临时 URL / provider media resolver
- 对于支持原厂直连的模型，允许在用户显式配置 API Key 后走原厂链路

这为后续将 Kling、Vidu、Pixverse 进一步统一接入百炼，同时保留原厂直连作为高级选项，打下了可扩展基础。

## 验证情况

已完成以下验证：

- `pytest -q`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run test:all`

验证结果：

- 后端测试通过
- TypeScript 类型检查通过
- 前端单元测试与 UI 测试通过

## 说明

- `npm run lint` 仍会命中仓库现有的历史基线问题，这些问题并非本 PR 新引入
- 当前分支已经推送完成，可直接进入代码审查
