### PR TITLE
feat: Playground (创作台) standalone generation module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Playground 创作台** — 全新独立生成模块，无需创建项目即可使用所有图像/视频生成能力
+  - 6 种生成模式：图像（T2I + I2I 自动识别）、文生视频、图生视频、参考生视频、视频编辑
+  - 两级模式选择器：图像生成 / 视频生成大类切换 + 视频子模式 pill
+  - 模型按 family 分组排序（视频: HappyHorse → Seedance → Kling → PixVerse → Wan → Vidu）
+  - 每个模型动态参数（GPT-Image-2: size+quality; Kling: mode+sound+cfgScale; Vidu: movementAmplitude+audio 等）
+  - 并发任务队列：可连续提交多个生成任务，右侧画廊实时显示状态
+  - 网格/画廊视图切换 + 详情面板（左图右信息，←→ 导航）
+  - Prompt 模板管理（新建/套用/收藏/删除）+ Prompt 历史（去重/搜索/一键复制/存为模板）
+  - 失败任务：重试 + 删除 + 复制报错全文
+  - 资产库双向打通：收藏到资产库（toggle）/ 从资产库选取作为输入
+  - 批量生成（抽卡 ×1/×2/×4）
+  - Session 时间分割线（30 分钟间隔自动分组）
+- **GlobalSidebar 创作台入口** — 侧边栏第 4 个导航项（Sparkles 图标）
+- **MuleRun 一键登录** — 设置页一键触发 OAuth 登录 + 重新登录按钮
+- **GPT-Image-2 扩展尺寸** — 支持 2K (2048×2048) 和 4K (3840×2160) via MuleRun
+
+### Changed
+- **Model catalog 参数精确化** — 所有 27 个 active 模型逐一声明 seed/negativePrompt/promptExtend/watermark 的 true/false，前端按模型动态显示高级参数
+- **WanxModel prompt_extend/watermark** — 改为 kwargs 优先读取（修复 Playground 传参被忽略的问题）
+- **PixVerse 路由** — Playground service 改为走 WanxModel 通道（与 pipeline 对齐）
+- **图像参数体系** — 图像模式显示 size（如 1024×1024 (1:1)），视频模式显示 resolution/ratio，不再混用
+
+### Deprecated
+- **Wan 2.6 全系列全局隐藏** — wan2.6-i2v、wan2.6-i2v-flash visible_in 清空 + wan2.6-r2v 标记 deprecated，Studio 和 Playground 统一不再展示
+- **Wan 2.5 / 2.2 系列** — 确认全部 deprecated + visible_in=[]
+
+### Fixed
+- **Vidu watermark 误标** — catalog 从 true 改为 false（代码中无此参数）
+- **收藏状态不同步** — 改为从 store generation 数据驱动（单一数据源），卡片/详情面板自动一致
+- **下载打开新标签** — 改为 fetch→blob→createObjectURL 强制浏览器下载
+- **筛选不显示失败任务** — 改为按 mode 判断分类，不依赖 outputs
+
 ---
 
 ## [1.1.0] - 2026-06-05

--- a/config/model_catalog/families/gpt-image.yaml
+++ b/config/model_catalog/families/gpt-image.yaml
@@ -41,5 +41,13 @@ models:
       order: 95
       badges: [new]
     params:
+      size:
+        options: ["1024x1024", "1536x1024", "1024x1536", "2048x2048", "2048x1152", "3840x2160", "2160x3840"]
+        default: "1024x1024"
+      quality:
+        options: ["high", "medium", "low"]
+        default: "high"
       negativePrompt: false
       seed: false
+      promptExtend: false
+      watermark: false

--- a/config/model_catalog/families/happyhorse.yaml
+++ b/config/model_catalog/families/happyhorse.yaml
@@ -59,9 +59,8 @@ models:
             options: [720p, 1080p]
             default: 1080p
           seed: true
-          # HappyHorse API supports watermark for all video modes.
-          # I2V does NOT support ratio (src/models/wanx.py:799 explicitly
-          # excludes happyhorse-1.0-i2v from the ratio payload).
+          negativePrompt: true
+          promptExtend: true
           watermark: true
         inputs:
           reference_images:
@@ -86,6 +85,8 @@ models:
             options: [720p, 1080p]
             default: 1080p
           seed: true
+          negativePrompt: true
+          promptExtend: true
           watermark: true
         inputs:
           reference_images:
@@ -108,6 +109,9 @@ models:
         options: [720p, 1080p]
         default: 1080p
       seed: true
+      negativePrompt: true
+      promptExtend: true
+      watermark: true
   # Standalone: V2V (hidden)
   - id: happyhorse-1.0-video-edit
     display_name: HappyHorse V2V
@@ -126,3 +130,6 @@ models:
         options: [720p, 1080p]
         default: 1080p
       seed: true
+      negativePrompt: true
+      promptExtend: true
+      watermark: true

--- a/config/model_catalog/families/kling.yaml
+++ b/config/model_catalog/families/kling.yaml
@@ -70,6 +70,9 @@ models:
           default: 5
         params:
           negativePrompt: true
+          seed: false
+          promptExtend: false
+          watermark: false
           mode:
             options: [std, pro]
             default: std
@@ -77,8 +80,6 @@ models:
             options: ["16:9", "9:16", "1:1"]
             default: "16:9"
           sound: true
-          audio: true
-          watermark: true
           cfgScale:
             min: 0
             max: 1
@@ -108,13 +109,15 @@ models:
           default: 5
         params:
           negativePrompt: true
+          seed: false
+          promptExtend: false
+          watermark: false
           mode:
             options: [std, pro]
             default: std
           aspectRatio:
             options: ["16:9", "9:16", "1:1"]
             default: "16:9"
-          watermark: true
         inputs:
           reference_images:
             max: 9

--- a/config/model_catalog/families/pixverse.yaml
+++ b/config/model_catalog/families/pixverse.yaml
@@ -59,6 +59,8 @@ models:
       audio: true
       watermark: true
       seed: true
+      negativePrompt: false
+      promptExtend: false
     inputs:
       reference_images:
         max: 1
@@ -100,6 +102,8 @@ models:
           audio: true
           watermark: true
           seed: true
+          negativePrompt: false
+          promptExtend: false
         inputs:
           reference_images:
             max: 1
@@ -127,6 +131,9 @@ models:
             options: [720p, 1080p]
             default: 720p
           seed: true
+          negativePrompt: false
+          promptExtend: false
+          watermark: false
         inputs:
           reference_images:
             max: 7
@@ -159,6 +166,9 @@ models:
         options: [720p, 1080p]
         default: 720p
       seed: true
+      negativePrompt: false
+      promptExtend: false
+      watermark: false
     inputs:
       reference_images:
         max: 7

--- a/config/model_catalog/families/qwen.yaml
+++ b/config/model_catalog/families/qwen.yaml
@@ -42,6 +42,9 @@ models:
       order: 100
       badges: [new]
     params:
+      size:
+        options: ["1024*1024", "1280*1280", "1440*1440", "2048*2048", "1280*720", "720*1280"]
+        default: "1280*1280"
       negativePrompt: true
       promptExtend: true
       watermark: true
@@ -63,6 +66,9 @@ models:
       visible_in: [project_settings, series_settings, global_settings]
       order: 90
     params:
+      size:
+        options: ["1024*1024", "1280*1280", "1440*1440", "2048*2048", "1280*720", "720*1280"]
+        default: "1280*1280"
       negativePrompt: true
       promptExtend: true
       watermark: true

--- a/config/model_catalog/families/seedance.yaml
+++ b/config/model_catalog/families/seedance.yaml
@@ -58,6 +58,8 @@ models:
             options: [720p, 1080p]
             default: 1080p
           seed: true
+          negativePrompt: false
+          promptExtend: false
           watermark: true
       i2v:
         legacy_id: seedance-2.0-i2v
@@ -80,6 +82,8 @@ models:
             options: [720p, 1080p]
             default: 1080p
           seed: true
+          negativePrompt: false
+          promptExtend: false
           watermark: true
         inputs:
           reference_images:
@@ -106,6 +110,8 @@ models:
             options: [720p, 1080p]
             default: 1080p
           seed: true
+          negativePrompt: false
+          promptExtend: false
           watermark: true
         docs:
           context_hub_doc_ids:

--- a/config/model_catalog/families/vidu.yaml
+++ b/config/model_catalog/families/vidu.yaml
@@ -71,6 +71,9 @@ models:
             options: [540p, 720p, 1080p]
             default: 720p
           seed: true
+          negativePrompt: false
+          promptExtend: false
+          watermark: false
           viduAudio: true
           movementAmplitude:
             options: [auto, small, medium, large]
@@ -103,7 +106,9 @@ models:
             options: [540p, 720p, 1080p]
             default: 720p
           seed: true
-          watermark: true
+          negativePrompt: false
+          promptExtend: false
+          watermark: false
         inputs:
           reference_images:
             max: 7
@@ -147,6 +152,9 @@ models:
             options: [540p, 720p, 1080p]
             default: 720p
           seed: true
+          negativePrompt: false
+          promptExtend: false
+          watermark: false
           viduAudio: true
           movementAmplitude:
             options: [auto, small, medium, large]
@@ -179,7 +187,9 @@ models:
             options: [540p, 720p, 1080p]
             default: 720p
           seed: true
-          watermark: true
+          negativePrompt: false
+          promptExtend: false
+          watermark: false
         inputs:
           reference_images:
             max: 7

--- a/config/model_catalog/families/wan.yaml
+++ b/config/model_catalog/families/wan.yaml
@@ -48,6 +48,14 @@ models:
       recommended: true
       order: 120
       badges: [latest]
+    params:
+      size:
+        options: ["1024*1024", "1280*1280", "1440*1440", "2048*2048", "1280*720", "720*1280", "1024*576", "576*1024"]
+        default: "1280*1280"
+      negativePrompt: true
+      seed: true
+      promptExtend: true
+      watermark: true
     inputs:
       reference_images:
         max: 9
@@ -67,6 +75,14 @@ models:
       selection_group: image
       visible_in: [project_settings, series_settings, global_settings]
       order: 110
+    params:
+      size:
+        options: ["1024*1024", "1280*1280", "1440*1440", "2048*2048", "1280*720", "720*1280", "1024*576", "576*1024"]
+        default: "1280*1280"
+      negativePrompt: true
+      seed: true
+      promptExtend: true
+      watermark: true
     inputs:
       reference_images:
         max: 9
@@ -135,6 +151,8 @@ models:
             options: [720p, 1080p]
             default: 1080p
           seed: true
+          negativePrompt: false
+          promptExtend: false
           watermark: true
         inputs:
           reference_images:
@@ -161,10 +179,10 @@ models:
           visible_in: []
           order: 2
 
-  # ── Wan 2.6 Video (legacy, still active) ──────────────────────────
+  # ── Wan 2.6 Video (deprecated — replaced by 2.7) ──────────────────
   - id: wan/wan2.6-video
     display_name: Wan 2.6 Video
-    description: Wan 2.6 video line
+    description: Wan 2.6 video line (deprecated)
     status: deprecated
     release_stage: stable
     docs:
@@ -176,11 +194,12 @@ models:
       i2v:
         legacy_id: wan2.6-i2v
         display_name: Wan 2.6 I2V / R2V
-        description: Legacy model, supports R2V
+        description: Legacy model, supports R2V (deprecated — replaced by 2.7)
+        status: deprecated
         capabilities: [i2v, r2v]
         ui:
           selection_group: i2v
-          visible_in: [project_settings, series_settings, video_sidebar, global_settings]
+          visible_in: []
           order: 75
         duration:
           type: slider
@@ -200,8 +219,8 @@ models:
       r2v:
         legacy_id: wan2.6-r2v
         display_name: Wan 2.6 R2V
-        description: Dedicated reference-to-video route
-        status: hidden
+        description: Dedicated reference-to-video route (deprecated — replaced by 2.7)
+        status: deprecated
         capabilities: [r2v]
         ui:
           selection_group: i2v
@@ -213,7 +232,7 @@ models:
             reference_type: video
   - id: wan2.6-i2v-flash
     display_name: Wan 2.6 I2V Flash
-    description: Fast generation
+    description: Fast generation (deprecated — replaced by 2.7)
     status: deprecated
     release_stage: stable
     capabilities: [i2v]
@@ -221,7 +240,7 @@ models:
       context_hub_doc_ids: [aliyun/wan-i2v-r2v]
     ui:
       selection_group: i2v
-      visible_in: [project_settings, series_settings, video_sidebar, global_settings]
+      visible_in: []
       order: 70
     duration:
       type: slider

--- a/config/model_catalog/generated/model_catalog.json
+++ b/config/model_catalog/generated/model_catalog.json
@@ -1711,7 +1711,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Fast generation",
+      "description": "Fast generation (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V Flash",
       "docs": {
         "context_hub_doc_ids": [
@@ -1885,7 +1885,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Wan 2.6 video line",
+      "description": "Wan 2.6 video line (deprecated)",
       "display_name": "Wan 2.6 Video",
       "docs": {
         "context_hub_doc_ids": [
@@ -2165,7 +2165,29 @@
       "inputs": {},
       "params": {
         "negativePrompt": false,
-        "seed": false
+        "promptExtend": false,
+        "quality": {
+          "default": "high",
+          "options": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "seed": false,
+        "size": {
+          "default": "1024x1024",
+          "options": [
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
+            "2048x2048",
+            "2048x1152",
+            "3840x2160",
+            "2160x3840"
+          ]
+        },
+        "watermark": false
       },
       "provider": "mulerouter",
       "release_stage": "stable",
@@ -2237,6 +2259,8 @@
         }
       },
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -2318,6 +2342,8 @@
         }
       },
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -2387,6 +2413,8 @@
       "id": "happyhorse-1.0-t2v",
       "inputs": {},
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -2394,7 +2422,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": true
       },
       "provider": "aliyun",
       "release_stage": "stable",
@@ -2450,6 +2479,8 @@
       "id": "happyhorse-1.0-video-edit",
       "inputs": {},
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -2457,7 +2488,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": true
       },
       "provider": "aliyun",
       "release_stage": "stable",
@@ -2537,7 +2569,6 @@
             "1:1"
           ]
         },
-        "audio": true,
         "cfgScale": {
           "default": 0.5,
           "max": 1,
@@ -2552,8 +2583,10 @@
           ]
         },
         "negativePrompt": true,
+        "promptExtend": false,
+        "seed": false,
         "sound": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "kling",
       "release_stage": "stable",
@@ -2654,7 +2687,9 @@
           ]
         },
         "negativePrompt": true,
-        "watermark": true
+        "promptExtend": false,
+        "seed": false,
+        "watermark": false
       },
       "provider": "kling",
       "release_stage": "stable",
@@ -2732,6 +2767,8 @@
       },
       "params": {
         "audio": true,
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -2815,6 +2852,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -2822,7 +2861,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": false
       },
       "provider": "pixverse",
       "release_stage": "stable",
@@ -2950,6 +2990,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -2957,7 +2999,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": false
       },
       "provider": "pixverse",
       "release_stage": "stable",
@@ -3031,6 +3074,8 @@
       },
       "params": {
         "audio": true,
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3116,6 +3161,17 @@
         "negativePrompt": true,
         "promptExtend": true,
         "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280"
+          ]
+        },
         "watermark": true
       },
       "provider": "aliyun",
@@ -3180,6 +3236,17 @@
         "negativePrompt": true,
         "promptExtend": true,
         "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280"
+          ]
+        },
         "watermark": true
       },
       "provider": "aliyun",
@@ -3253,6 +3320,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -3336,6 +3405,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -3414,6 +3485,8 @@
       "id": "seedance-2.0-t2v",
       "inputs": {},
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -3510,6 +3583,8 @@
             "large"
           ]
         },
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3603,6 +3678,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3612,7 +3689,7 @@
           ]
         },
         "seed": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "vidu",
       "release_stage": "stable",
@@ -3702,6 +3779,8 @@
             "large"
           ]
         },
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3793,6 +3872,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3802,7 +3883,7 @@
           ]
         },
         "seed": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "vidu",
       "release_stage": "stable",
@@ -4304,7 +4385,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Legacy model, supports R2V",
+      "description": "Legacy model, supports R2V (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V / R2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -4367,12 +4448,7 @@
         "order": 75,
         "recommended": false,
         "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
+        "visible_in": []
       }
     },
     "wan2.6-i2v-flash": {
@@ -4386,7 +4462,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Fast generation",
+      "description": "Fast generation (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V Flash",
       "docs": {
         "context_hub_doc_ids": [
@@ -4449,12 +4525,7 @@
         "order": 70,
         "recommended": false,
         "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
+        "visible_in": []
       }
     },
     "wan2.6-image": {
@@ -4529,7 +4600,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Dedicated reference-to-video route",
+      "description": "Dedicated reference-to-video route (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 R2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -4557,7 +4628,7 @@
         "wan2.6-",
         "wan2.7-"
       ],
-      "status": "hidden",
+      "status": "deprecated",
       "supported_backends": [
         "dashscope"
       ],
@@ -4764,7 +4835,25 @@
           "max": 9
         }
       },
-      "params": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280",
+            "1024*576",
+            "576*1024"
+          ]
+        },
+        "watermark": true
+      },
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
@@ -4830,7 +4919,25 @@
           "max": 9
         }
       },
-      "params": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280",
+            "1024*576",
+            "576*1024"
+          ]
+        },
+        "watermark": true
+      },
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
@@ -4905,6 +5012,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5098,7 +5207,29 @@
       "model_line_id": "gpt-image/gpt-image-2",
       "params": {
         "negativePrompt": false,
-        "seed": false
+        "promptExtend": false,
+        "quality": {
+          "default": "high",
+          "options": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "seed": false,
+        "size": {
+          "default": "1024x1024",
+          "options": [
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
+            "2048x2048",
+            "2048x1152",
+            "3840x2160",
+            "2160x3840"
+          ]
+        },
+        "watermark": false
       },
       "provider": "mulerouter",
       "release_stage": "stable",
@@ -5168,6 +5299,8 @@
       "mode": "i2v",
       "model_line_id": "happyhorse/happyhorse-1.0-t2v",
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5175,7 +5308,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": true
       },
       "provider": "aliyun",
       "release_stage": "stable",
@@ -5245,6 +5379,8 @@
       "mode": "i2v",
       "model_line_id": "happyhorse/happyhorse-1.0-video",
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5334,6 +5470,8 @@
       "mode": "r2v",
       "model_line_id": "happyhorse/happyhorse-1.0-video",
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5411,6 +5549,8 @@
       "mode": "i2v",
       "model_line_id": "happyhorse/happyhorse-1.0-video-edit",
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5418,7 +5558,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": true
       },
       "provider": "aliyun",
       "release_stage": "stable",
@@ -5502,7 +5643,6 @@
             "1:1"
           ]
         },
-        "audio": true,
         "cfgScale": {
           "default": 0.5,
           "max": 1,
@@ -5517,8 +5657,10 @@
           ]
         },
         "negativePrompt": true,
+        "promptExtend": false,
+        "seed": false,
         "sound": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "kling",
       "release_stage": "stable",
@@ -5631,7 +5773,9 @@
           ]
         },
         "negativePrompt": true,
-        "watermark": true
+        "promptExtend": false,
+        "seed": false,
+        "watermark": false
       },
       "provider": "kling",
       "release_stage": "stable",
@@ -5721,6 +5865,8 @@
       "model_line_id": "pixverse/pixverse-c1-video",
       "params": {
         "audio": true,
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -5813,6 +5959,8 @@
       "mode": "r2v",
       "model_line_id": "pixverse/pixverse-c1-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -5820,7 +5968,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": false
       },
       "provider": "pixverse",
       "release_stage": "stable",
@@ -5961,6 +6110,8 @@
       "mode": "r2v",
       "model_line_id": "pixverse/pixverse-v5.6-r2v",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -5968,7 +6119,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": false
       },
       "provider": "pixverse",
       "release_stage": "stable",
@@ -6051,6 +6203,8 @@
       "model_line_id": "pixverse/pixverse/pixverse-v6-video",
       "params": {
         "audio": true,
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6145,6 +6299,17 @@
         "negativePrompt": true,
         "promptExtend": true,
         "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280"
+          ]
+        },
         "watermark": true
       },
       "provider": "aliyun",
@@ -6218,6 +6383,17 @@
         "negativePrompt": true,
         "promptExtend": true,
         "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280"
+          ]
+        },
         "watermark": true
       },
       "provider": "aliyun",
@@ -6300,6 +6476,8 @@
       "mode": "i2v",
       "model_line_id": "seedance/seedance-2.0-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -6391,6 +6569,8 @@
       "mode": "r2v",
       "model_line_id": "seedance/seedance-2.0-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -6477,6 +6657,8 @@
       "mode": "t2v",
       "model_line_id": "seedance/seedance-2.0-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -6581,6 +6763,8 @@
             "large"
           ]
         },
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6686,6 +6870,8 @@
       "mode": "r2v",
       "model_line_id": "vidu/viduq3-pro-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6695,7 +6881,7 @@
           ]
         },
         "seed": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "vidu",
       "release_stage": "stable",
@@ -6797,6 +6983,8 @@
             "large"
           ]
         },
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6900,6 +7088,8 @@
       "mode": "r2v",
       "model_line_id": "vidu/viduq3-turbo-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6909,7 +7099,7 @@
           ]
         },
         "seed": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "vidu",
       "release_stage": "stable",
@@ -7447,7 +7637,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Fast generation",
+      "description": "Fast generation (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V Flash",
       "docs": {
         "context_hub_doc_ids": [
@@ -7514,12 +7704,7 @@
         "order": 70,
         "recommended": false,
         "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
+        "visible_in": []
       }
     },
     "wan/wan2.6-image#i2i": {
@@ -7660,7 +7845,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Legacy model, supports R2V",
+      "description": "Legacy model, supports R2V (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V / R2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -7731,12 +7916,7 @@
         "order": 75,
         "recommended": false,
         "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
+        "visible_in": []
       }
     },
     "wan/wan2.6-video#r2v": {
@@ -7750,7 +7930,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Dedicated reference-to-video route",
+      "description": "Dedicated reference-to-video route (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 R2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -7786,7 +7966,7 @@
           "gateway": "dashscope"
         }
       },
-      "status": "hidden",
+      "status": "deprecated",
       "supported_backends": [
         "dashscope"
       ],
@@ -7842,7 +8022,25 @@
       "legacy_model_id": "wan2.7-image",
       "mode": "image",
       "model_line_id": "wan/wan2.7-image",
-      "params": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280",
+            "1024*576",
+            "576*1024"
+          ]
+        },
+        "watermark": true
+      },
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
@@ -7917,7 +8115,25 @@
       "legacy_model_id": "wan2.7-image-pro",
       "mode": "image",
       "model_line_id": "wan/wan2.7-image-pro",
-      "params": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280",
+            "1024*576",
+            "576*1024"
+          ]
+        },
+        "watermark": true
+      },
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
@@ -8106,6 +8322,8 @@
       "mode": "r2v",
       "model_line_id": "wan/wan2.7-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [

--- a/docs/design/mock-07-playground.html
+++ b/docs/design/mock-07-playground.html
@@ -1,0 +1,1430 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LumenX Studio — Playground Mock (Cinematic Restraint)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+<style>
+/* ═══ SEED TOKENS ═══ */
+:root {
+  --seed-bg: #050508;
+  --seed-fg: #ededed;
+  --seed-primary: #646cff;
+  --seed-secondary: #535bf2;
+  --seed-accent: #ff0080;
+  --seed-surface: rgba(255,255,255,0.04);
+  --seed-radius: 8px;
+}
+
+/* ═══ SEMANTIC TOKENS ═══ */
+:root {
+  --color-bg-base: var(--seed-bg);
+  --color-bg-surface: var(--seed-surface);
+  --color-bg-elevated: #141416;
+  --color-bg-inset: rgba(255,255,255,0.02);
+  --color-bg-hover: rgba(255,255,255,0.06);
+  --color-bg-input: rgba(0,0,0,0.3);
+  --color-text-primary: var(--seed-fg);
+  --color-text-secondary: #9ca3af;
+  --color-text-muted: #6b7280;
+  --color-border-default: rgba(255,255,255,0.08);
+  --color-border-subtle: rgba(255,255,255,0.04);
+  --color-primary: var(--seed-primary);
+  --color-primary-hover: var(--seed-secondary);
+  --color-accent: var(--seed-accent);
+  --color-overlay: rgba(0,0,0,0.85);
+  --color-status-pending-fg: oklch(0.85 0.13 230);
+  --color-status-pending-bg: oklch(0.75 0.16 230 / 0.10);
+  --color-status-pending-border: oklch(0.75 0.16 230 / 0.45);
+  --color-status-processing-fg: oklch(0.88 0.16 80);
+  --color-status-processing-bg: oklch(0.78 0.18 80 / 0.10);
+  --color-status-processing-border: oklch(0.78 0.18 80 / 0.45);
+  --color-status-completed-fg: oklch(0.88 0.16 155);
+  --color-status-completed-bg: oklch(0.78 0.18 155 / 0.10);
+  --color-status-completed-border: oklch(0.78 0.18 155 / 0.45);
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-body: 'Inter', sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --shadow-subtle: 0 1px 2px rgba(0,0,0,0.4);
+  --shadow-elevated: 0 8px 32px rgba(0,0,0,0.6);
+  --duration-fast: 150ms;
+  --duration-base: 250ms;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: var(--color-bg-base);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow: hidden;
+  height: 100vh;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ═══ LAYOUT ═══ */
+.app-shell { display: flex; height: 100vh; width: 100vw; }
+
+/* ─── Global Sidebar ─── */
+.global-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  height: 100%;
+  border-right: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(2px);
+}
+.sidebar-brand {
+  padding: 20px 16px 18px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.brand-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 5px;
+  background: linear-gradient(135deg, #7c3aed, #4f46e5, #ec4899);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 11px;
+  color: #fff;
+}
+.brand-text {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text-primary);
+}
+.sidebar-nav {
+  flex: 1;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease);
+  position: relative;
+  border: 1px solid transparent;
+}
+.nav-item svg {
+  width: 18px;
+  height: 18px;
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+.nav-item:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-hover);
+}
+.nav-item.active {
+  color: var(--color-text-primary);
+  background: rgba(100,108,255,0.08);
+  border-color: rgba(100,108,255,0.15);
+}
+.nav-item.active svg {
+  opacity: 1;
+  color: var(--color-primary);
+}
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 25%;
+  height: 50%;
+  width: 2px;
+  background: var(--color-primary);
+  border-radius: 0 2px 2px 0;
+}
+.sidebar-footer {
+  padding: 16px;
+  border-top: 1px solid var(--color-border-subtle);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-muted);
+  padding-left: 26px;
+}
+
+/* ─── Main Content ─── */
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+/* Page Header (aligned with mock-01/04/05 style) */
+.page-header {
+  padding: 20px 28px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+.page-title {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+}
+.page-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+  margin-left: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.page-header-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.page-mode-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  padding: 4px 8px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+}
+
+/* ─── Playground Split Layout ─── */
+.playground-layout {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* ═══ LEFT: INPUT PANEL ═══ */
+.input-panel {
+  width: 420px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--color-border-default);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  background: var(--color-bg-inset);
+}
+.input-panel::-webkit-scrollbar { width: 4px; }
+.input-panel::-webkit-scrollbar-track { background: transparent; }
+.input-panel::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+
+.input-section {
+  padding: 20px 24px;
+}
+.input-section + .input-section {
+  border-top: 1px solid var(--color-border-subtle);
+}
+.input-section-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-text-muted);
+  margin-bottom: 12px;
+}
+
+/* Mode Tabs */
+.mode-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 3px;
+  background: rgba(255,255,255,0.03);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+}
+.mode-tab {
+  flex: 1;
+  padding: 8px 6px;
+  border-radius: 6px;
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: center;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease);
+  white-space: nowrap;
+}
+.mode-tab:hover {
+  color: var(--color-text-secondary);
+  background: rgba(255,255,255,0.04);
+}
+.mode-tab.active {
+  color: var(--color-text-primary);
+  background: var(--color-primary);
+  box-shadow: 0 2px 8px rgba(100,108,255,0.3);
+}
+
+/* Model Selector */
+.model-selector {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-input);
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease);
+}
+.model-selector:hover {
+  border-color: rgba(255,255,255,0.15);
+}
+.model-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-status-completed-fg);
+  flex-shrink: 0;
+}
+.model-name {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+.model-provider {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.model-chevron {
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
+/* Media Input Zone */
+.media-input-zone {
+  border: 1px dashed var(--color-border-default);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+  transition: border-color var(--duration-fast) var(--ease), background var(--duration-fast) var(--ease);
+  cursor: pointer;
+}
+.media-input-zone:hover {
+  border-color: rgba(255,255,255,0.15);
+  background: rgba(255,255,255,0.02);
+}
+.media-input-zone.has-media {
+  border-style: solid;
+  padding: 12px;
+  align-items: stretch;
+}
+.media-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--color-text-muted);
+}
+.media-input-text {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.media-input-hint {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+.media-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+.media-action-btn {
+  padding: 6px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease);
+}
+.media-action-btn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+.media-action-btn.from-library {
+  border-color: rgba(100,108,255,0.3);
+  color: var(--color-primary);
+}
+.media-action-btn.from-library:hover {
+  background: rgba(100,108,255,0.08);
+}
+
+/* Media Preview (when image is loaded) */
+.media-preview-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+.media-thumb {
+  width: 80px;
+  height: 60px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-elevated);
+  overflow: hidden;
+  position: relative;
+  flex-shrink: 0;
+}
+.media-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.media-thumb-remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+}
+.media-thumb:hover .media-thumb-remove { opacity: 1; }
+.media-thumb-info {
+  flex: 1;
+  min-width: 0;
+}
+.media-thumb-name {
+  font-size: 12px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.media-thumb-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-muted);
+  margin-top: 2px;
+}
+
+/* Prompt Input */
+.prompt-wrapper {
+  position: relative;
+}
+.prompt-textarea {
+  width: 100%;
+  min-height: 120px;
+  max-height: 200px;
+  resize: vertical;
+  padding: 14px 14px 40px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-input);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.6;
+  transition: border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease);
+}
+.prompt-textarea::placeholder {
+  color: var(--color-text-muted);
+}
+.prompt-textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(100,108,255,0.12);
+}
+.prompt-toolbar {
+  position: absolute;
+  bottom: 10px;
+  left: 12px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.prompt-tool-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease);
+  border: none;
+  background: transparent;
+}
+.prompt-tool-btn:hover {
+  color: var(--color-text-secondary);
+  background: rgba(255,255,255,0.06);
+}
+.prompt-tool-btn svg { width: 14px; height: 14px; }
+.prompt-char-count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-muted);
+}
+
+/* Negative Prompt (collapsible) */
+.neg-prompt-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 0;
+  font-size: 11px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color var(--duration-fast);
+}
+.neg-prompt-toggle:hover { color: var(--color-text-secondary); }
+.neg-prompt-toggle .chevron {
+  font-size: 10px;
+  transition: transform var(--duration-fast);
+}
+.neg-prompt-toggle.open .chevron { transform: rotate(90deg); }
+.neg-prompt-area {
+  margin-top: 8px;
+}
+.neg-prompt-input {
+  width: 100%;
+  min-height: 60px;
+  resize: vertical;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-input);
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.neg-prompt-input::placeholder { color: var(--color-text-muted); }
+.neg-prompt-input:focus {
+  outline: none;
+  border-color: rgba(255,255,255,0.12);
+}
+
+/* Parameter Bar */
+.param-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.param-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.param-item.full-width { grid-column: 1 / -1; }
+.param-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+.param-select {
+  padding: 8px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-input);
+  color: var(--color-text-primary);
+  font-size: 12px;
+  appearance: none;
+  cursor: pointer;
+}
+.param-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+/* Batch Count Selector */
+.batch-selector {
+  display: flex;
+  gap: 4px;
+  padding: 3px;
+  background: rgba(255,255,255,0.03);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+}
+.batch-pill {
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease);
+}
+.batch-pill:hover {
+  color: var(--color-text-secondary);
+  background: rgba(255,255,255,0.04);
+}
+.batch-pill.active {
+  color: var(--color-text-primary);
+  background: var(--color-primary);
+  box-shadow: 0 1px 4px rgba(100,108,255,0.3);
+}
+
+/* Advanced Params (collapsible) */
+.advanced-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color var(--duration-fast);
+}
+.advanced-toggle:hover { color: var(--color-text-secondary); }
+.advanced-toggle .arrow {
+  font-size: 10px;
+  transition: transform var(--duration-fast);
+}
+
+/* Generate CTA */
+.generate-section {
+  padding: 20px 24px;
+  border-top: 1px solid var(--color-border-default);
+  margin-top: auto;
+  position: sticky;
+  bottom: 0;
+  background: var(--color-bg-base);
+}
+.generate-btn {
+  width: 100%;
+  padding: 14px 24px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-primary);
+  color: #fff;
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease);
+  position: relative;
+  overflow: hidden;
+}
+.generate-btn:hover {
+  background: var(--color-primary-hover);
+  box-shadow: 0 4px 20px rgba(100,108,255,0.35);
+}
+.generate-btn:active {
+  transform: scale(0.98);
+}
+.generate-btn .btn-glow {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(124,58,237,0.2), rgba(100,108,255,0.1), rgba(236,72,153,0.15));
+  opacity: 0;
+  transition: opacity var(--duration-base);
+}
+.generate-btn:hover .btn-glow { opacity: 1; }
+
+/* ═══ RIGHT: RESULT GALLERY ═══ */
+.result-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+.result-header {
+  padding: 16px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+.result-title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-text-muted);
+}
+.result-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+  padding: 3px 8px;
+  background: rgba(255,255,255,0.04);
+  border-radius: var(--radius-sm);
+}
+.result-filter-row {
+  display: flex;
+  gap: 6px;
+}
+.result-filter-btn {
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: transparent;
+  transition: all var(--duration-fast);
+}
+.result-filter-btn:hover { color: var(--color-text-secondary); background: var(--color-bg-hover); }
+.result-filter-btn.active { color: var(--color-text-primary); border-color: var(--color-border-default); background: var(--color-bg-hover); }
+
+.result-gallery {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 28px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+  align-content: start;
+}
+.result-gallery::-webkit-scrollbar { width: 4px; }
+.result-gallery::-webkit-scrollbar-track { background: transparent; }
+.result-gallery::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+
+/* Result Card */
+.result-card {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  overflow: hidden;
+  transition: border-color var(--duration-fast) var(--ease), transform var(--duration-fast) var(--ease);
+  cursor: pointer;
+}
+.result-card:hover {
+  border-color: rgba(255,255,255,0.15);
+  transform: translateY(-2px);
+}
+.result-card-media {
+  aspect-ratio: 16/9;
+  background: var(--color-bg-elevated);
+  position: relative;
+  overflow: hidden;
+}
+.result-card-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.result-card-media .video-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  padding: 3px 7px;
+  border-radius: var(--radius-sm);
+  background: rgba(0,0,0,0.7);
+  backdrop-filter: blur(4px);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.result-card-media .video-badge .play-icon {
+  width: 8px;
+  height: 8px;
+}
+.result-card-media .duration-badge {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: rgba(0,0,0,0.7);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: rgba(255,255,255,0.8);
+}
+/* Hover overlay */
+.result-card-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+}
+.result-card:hover .result-card-overlay { opacity: 1; }
+.result-card-action {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.15);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255,255,255,0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+.result-card-action:hover {
+  background: rgba(255,255,255,0.25);
+  transform: scale(1.1);
+}
+.result-card-action svg { width: 14px; height: 14px; color: #fff; }
+
+.result-card-info {
+  padding: 10px 12px;
+}
+.result-card-prompt {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.4;
+}
+.result-card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 8px;
+}
+.result-card-model {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 2px 6px;
+  background: rgba(255,255,255,0.04);
+  border-radius: 3px;
+}
+.result-card-time {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--color-text-muted);
+}
+.result-card-saved {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  color: var(--color-status-completed-fg);
+}
+
+/* Processing/Skeleton Card */
+.result-card.processing .result-card-media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 12px;
+}
+.skeleton-shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, transparent 25%, rgba(255,255,255,0.04) 37%, transparent 63%);
+  animation: shimmer 2s ease-in-out infinite;
+}
+@keyframes shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+.processing-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid rgba(255,255,255,0.1);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  z-index: 1;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.processing-text {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  z-index: 1;
+}
+.processing-progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: var(--color-primary);
+  border-radius: 0 2px 0 0;
+  transition: width 0.3s linear;
+}
+
+/* Gallery empty state */
+.gallery-empty {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 40px;
+  text-align: center;
+}
+.gallery-empty-icon {
+  width: 48px;
+  height: 48px;
+  color: var(--color-text-muted);
+  opacity: 0.4;
+  margin-bottom: 16px;
+}
+.gallery-empty-text {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  margin-bottom: 4px;
+}
+.gallery-empty-hint {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  opacity: 0.6;
+}
+
+/* Session divider */
+.session-divider {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+}
+.session-divider::before,
+.session-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border-subtle);
+}
+.session-divider-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  white-space: nowrap;
+}
+
+/* ═══ UTILITY ═══ */
+.flex-between { display: flex; align-items: center; justify-content: space-between; }
+</style>
+</head>
+<body>
+<div class="app-shell">
+  <!-- ═══ GLOBAL SIDEBAR ═══ -->
+  <aside class="global-sidebar" data-component="GlobalSidebar">
+    <div class="sidebar-brand">
+      <div class="brand-icon">X</div>
+      <span class="brand-text">LumenX Studio</span>
+    </div>
+    <nav class="sidebar-nav">
+      <div class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg>
+        <span>工作区</span>
+      </div>
+      <div class="nav-item active">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
+        <span>试验台</span>
+      </div>
+      <div class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
+        <span>资产库</span>
+      </div>
+      <div class="nav-item">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06A1.65 1.65 0 009 4.68 1.65 1.65 0 0010 3.17V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+        <span>设置</span>
+      </div>
+    </nav>
+    <div class="sidebar-footer">v0.2.0</div>
+  </aside>
+
+  <!-- ═══ MAIN CONTENT ═══ -->
+  <div class="main-content" data-component="PlaygroundPage">
+    <!-- Header -->
+    <div class="page-header">
+      <div>
+        <span class="page-title">试验台</span>
+        <span class="page-count">12 RESULTS</span>
+      </div>
+      <div class="page-header-meta">
+        <span class="page-mode-tag">图生视频</span>
+      </div>
+    </div>
+
+    <!-- Split Layout -->
+    <div class="playground-layout">
+      <!-- ═══ LEFT: INPUT PANEL ═══ -->
+      <div class="input-panel" data-component="InputPanel">
+
+        <!-- Section: Mode Selector -->
+        <div class="input-section">
+          <div class="input-section-label">生成模式</div>
+          <div class="mode-tabs" data-component="ModeSelector">
+            <div class="mode-tab">文生图</div>
+            <div class="mode-tab">图生图</div>
+            <div class="mode-tab">文生视频</div>
+            <div class="mode-tab active">图生视频</div>
+            <div class="mode-tab">参考视频</div>
+            <div class="mode-tab">视频编辑</div>
+          </div>
+        </div>
+
+        <!-- Section: Model Selector -->
+        <div class="input-section">
+          <div class="input-section-label">模型</div>
+          <div class="model-selector" data-component="ModelSelector">
+            <span class="model-dot"></span>
+            <span class="model-name">Seedance 2.0</span>
+            <span class="model-provider">ByteDance</span>
+            <span class="model-chevron">▾</span>
+          </div>
+        </div>
+
+        <!-- Section: Media Input (i2v mode shows reference image) -->
+        <div class="input-section">
+          <div class="input-section-label">首帧图片</div>
+          <div class="media-input-zone has-media" data-component="MediaInput">
+            <div class="media-preview-row">
+              <div class="media-thumb">
+                <!-- Simulated uploaded image (gradient placeholder) -->
+                <div style="width:100%;height:100%;background:linear-gradient(135deg,#1a1a3e 0%,#2d1b4e 50%,#1b2838 100%)"></div>
+                <span class="media-thumb-remove">×</span>
+              </div>
+              <div class="media-thumb-info">
+                <div class="media-thumb-name">cyberpunk_girl_ref.png</div>
+                <div class="media-thumb-meta">1024 × 576 · PNG · 2.1 MB</div>
+              </div>
+            </div>
+            <div class="media-actions" style="margin-top:10px">
+              <button class="media-action-btn">替换文件</button>
+              <button class="media-action-btn from-library">从资产库选取</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Section: Prompt Input -->
+        <div class="input-section">
+          <div class="input-section-label">Prompt</div>
+          <div class="prompt-wrapper" data-component="PromptInput">
+            <textarea class="prompt-textarea" placeholder="描述你想生成的内容...">A cyberpunk girl walking through neon-lit rain streets, camera slowly dollying forward, volumetric fog, cinematic lighting, shallow depth of field, 24fps film grain</textarea>
+            <div class="prompt-toolbar">
+              <button class="prompt-tool-btn">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                模板
+              </button>
+              <button class="prompt-tool-btn">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12,6 12,12 16,14"/></svg>
+                历史
+              </button>
+              <span class="prompt-char-count">156 / 2000</span>
+            </div>
+          </div>
+          <!-- Negative Prompt -->
+          <div class="neg-prompt-toggle open" style="margin-top:10px">
+            <span class="chevron">▸</span>
+            <span>负面提示词</span>
+          </div>
+          <div class="neg-prompt-area">
+            <textarea class="neg-prompt-input" placeholder="不希望出现的内容...">blurry, low quality, deformed hands, watermark, text overlay</textarea>
+          </div>
+        </div>
+
+        <!-- Section: Parameters -->
+        <div class="input-section" data-component="ParameterBar">
+          <div class="input-section-label">参数</div>
+          <div class="param-grid">
+            <div class="param-item">
+              <span class="param-label">宽高比</span>
+              <select class="param-select">
+                <option selected>16:9</option>
+                <option>9:16</option>
+                <option>1:1</option>
+                <option>4:3</option>
+              </select>
+            </div>
+            <div class="param-item">
+              <span class="param-label">分辨率</span>
+              <select class="param-select">
+                <option>480P</option>
+                <option selected>720P</option>
+                <option>1080P</option>
+              </select>
+            </div>
+            <div class="param-item">
+              <span class="param-label">时长</span>
+              <select class="param-select">
+                <option>3s</option>
+                <option selected>5s</option>
+                <option>10s</option>
+              </select>
+            </div>
+            <div class="param-item">
+              <span class="param-label">生成数量</span>
+              <div class="batch-selector">
+                <span class="batch-pill">×1</span>
+                <span class="batch-pill active">×2</span>
+                <span class="batch-pill">×4</span>
+              </div>
+            </div>
+          </div>
+          <!-- Advanced toggle -->
+          <div class="advanced-toggle" style="margin-top:12px">
+            <span class="arrow">▸</span>
+            <span>高级参数</span>
+          </div>
+        </div>
+
+        <!-- Generate CTA -->
+        <div class="generate-section">
+          <button class="generate-btn">
+            <span class="btn-glow"></span>
+            生成 ×2
+          </button>
+        </div>
+      </div>
+
+      <!-- ═══ RIGHT: RESULT GALLERY ═══ -->
+      <div class="result-panel" data-component="ResultGallery">
+        <div class="result-header">
+          <div style="display:flex;align-items:center;gap:12px">
+            <span class="result-title">生成结果</span>
+            <span class="result-count">12</span>
+          </div>
+          <div class="result-filter-row">
+            <button class="result-filter-btn active">全部</button>
+            <button class="result-filter-btn">图片</button>
+            <button class="result-filter-btn">视频</button>
+          </div>
+        </div>
+        <div class="result-gallery">
+          <!-- Card 1: Processing (current batch) -->
+          <div class="result-card processing" data-component="ResultCard">
+            <div class="result-card-media">
+              <div class="skeleton-shimmer"></div>
+              <div class="processing-spinner"></div>
+              <div class="processing-text">生成中…</div>
+              <div class="processing-progress" style="width:45%"></div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">A cyberpunk girl walking through neon-lit rain streets…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">seedance 2.0</span>
+                <span class="result-card-time">刚刚</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 2: Processing (current batch, second) -->
+          <div class="result-card processing">
+            <div class="result-card-media">
+              <div class="skeleton-shimmer"></div>
+              <div class="processing-spinner"></div>
+              <div class="processing-text">排队中…</div>
+              <div class="processing-progress" style="width:10%"></div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">A cyberpunk girl walking through neon-lit rain streets…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">seedance 2.0</span>
+                <span class="result-card-time">刚刚</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 3: Completed video -->
+          <div class="result-card">
+            <div class="result-card-media">
+              <div style="width:100%;height:100%;background:linear-gradient(160deg,#0d1117 0%,#1a0a2e 40%,#16213e 70%,#0d1117 100%)"></div>
+              <span class="video-badge">
+                <svg class="play-icon" viewBox="0 0 24 24" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+                I2V
+              </span>
+              <span class="duration-badge">5.0s</span>
+              <div class="result-card-overlay">
+                <div class="result-card-action" title="预览">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="result-card-action" title="下载">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="result-card-action" title="收藏到资产库">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                </div>
+              </div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">Futuristic cityscape at sunset, flying vehicles…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">seedance 2.0</span>
+                <span class="result-card-time">3 分钟前</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 4: Completed video (saved) -->
+          <div class="result-card">
+            <div class="result-card-media">
+              <div style="width:100%;height:100%;background:linear-gradient(145deg,#1a0a2e 0%,#2d1b69 30%,#0d1b2a 70%,#162447 100%)"></div>
+              <span class="video-badge">
+                <svg class="play-icon" viewBox="0 0 24 24" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+                I2V
+              </span>
+              <span class="duration-badge">5.0s</span>
+              <div class="result-card-overlay">
+                <div class="result-card-action" title="预览">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="result-card-action" title="下载">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="result-card-action" title="已收藏">
+                  <svg viewBox="0 0 24 24" fill="var(--color-status-starred-fg)" stroke="var(--color-status-starred-fg)" stroke-width="2"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                </div>
+              </div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">Ethereal dance sequence, slow motion silk fabric…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">kling v3</span>
+                <span class="result-card-saved">
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                  已收藏
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 5: Completed image -->
+          <div class="result-card">
+            <div class="result-card-media">
+              <div style="width:100%;height:100%;background:linear-gradient(135deg,#1b2838 0%,#2a1a3e 35%,#0f172a 60%,#1e1b4b 100%)"></div>
+              <div class="result-card-overlay">
+                <div class="result-card-action" title="预览">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="result-card-action" title="下载">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="result-card-action" title="生成视频">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23,7 16,12 23,17"/><rect x="1" y="5" width="15" height="14" rx="2"/></svg>
+                </div>
+                <div class="result-card-action" title="收藏">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                </div>
+              </div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">Character design: female samurai in neo-Tokyo armor…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">wan 2.7 pro</span>
+                <span class="result-card-time">15 分钟前</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 6: Completed image -->
+          <div class="result-card">
+            <div class="result-card-media">
+              <div style="width:100%;height:100%;background:linear-gradient(180deg,#0f0c29 0%,#302b63 50%,#24243e 100%)"></div>
+              <div class="result-card-overlay">
+                <div class="result-card-action" title="预览">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="result-card-action" title="下载">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="result-card-action" title="生成视频">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23,7 16,12 23,17"/><rect x="1" y="5" width="15" height="14" rx="2"/></svg>
+                </div>
+                <div class="result-card-action" title="收藏">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                </div>
+              </div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">Mystical forest with bioluminescent flora, ancient stone…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">gpt-image-2</span>
+                <span class="result-card-time">15 分钟前</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Session divider: earlier session -->
+          <div class="session-divider">
+            <span class="session-divider-label">今天 · 14:20</span>
+          </div>
+
+          <!-- Card 7: Earlier result (video) -->
+          <div class="result-card">
+            <div class="result-card-media">
+              <div style="width:100%;height:100%;background:linear-gradient(135deg,#0c0c1d 0%,#1a0a2e 40%,#0d1117 100%)"></div>
+              <span class="video-badge">
+                <svg class="play-icon" viewBox="0 0 24 24" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg>
+                T2V
+              </span>
+              <span class="duration-badge">3.0s</span>
+              <div class="result-card-overlay">
+                <div class="result-card-action" title="预览">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="result-card-action" title="下载">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="result-card-action" title="收藏">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                </div>
+              </div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">Ocean waves crashing against cliff at golden hour…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">seedance 2.0</span>
+                <span class="result-card-time">14:22</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 8: Earlier result (image) -->
+          <div class="result-card">
+            <div class="result-card-media">
+              <div style="width:100%;height:100%;background:linear-gradient(135deg,#0f2027 0%,#203a43 50%,#2c5364 100%)"></div>
+              <div class="result-card-overlay">
+                <div class="result-card-action" title="预览">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="result-card-action" title="下载">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="result-card-action" title="生成视频">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23,7 16,12 23,17"/><rect x="1" y="5" width="15" height="14" rx="2"/></svg>
+                </div>
+                <div class="result-card-action" title="收藏">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                </div>
+              </div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">Concept art: abandoned space station corridor…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">qwen 2.0 pro</span>
+                <span class="result-card-time">14:20</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 9: Earlier result (image, saved) -->
+          <div class="result-card">
+            <div class="result-card-media">
+              <div style="width:100%;height:100%;background:linear-gradient(160deg,#1a1a2e 0%,#16213e 40%,#0f3460 100%)"></div>
+              <div class="result-card-overlay">
+                <div class="result-card-action" title="预览">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="result-card-action" title="下载">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="result-card-action" title="已收藏">
+                  <svg viewBox="0 0 24 24" fill="var(--color-status-starred-fg)" stroke="var(--color-status-starred-fg)" stroke-width="2"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                </div>
+              </div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">Mech pilot portrait, helmet visor reflection…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">wan 2.5</span>
+                <span class="result-card-saved">
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                  已收藏
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Card 10: Earliest result -->
+          <div class="result-card">
+            <div class="result-card-media">
+              <div style="width:100%;height:100%;background:linear-gradient(135deg,#1f1c2c 0%,#928dab 100%);opacity:0.7"></div>
+              <div class="result-card-overlay">
+                <div class="result-card-action" title="预览">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </div>
+                <div class="result-card-action" title="下载">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="result-card-action" title="生成视频">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23,7 16,12 23,17"/><rect x="1" y="5" width="15" height="14" rx="2"/></svg>
+                </div>
+                <div class="result-card-action" title="收藏">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg>
+                </div>
+              </div>
+            </div>
+            <div class="result-card-info">
+              <div class="result-card-prompt">Abstract particle flow, blue to purple gradient…</div>
+              <div class="result-card-meta">
+                <span class="result-card-model">wan 2.7 pro</span>
+                <span class="result-card-time">14:18</span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/plans/2026-06-06-playground-standalone-generation-prd.md
+++ b/docs/plans/2026-06-06-playground-standalone-generation-prd.md
@@ -1,0 +1,394 @@
+# LumenX Playground — 独立生成模块 PRD
+
+> **版本**: v1.0  
+> **日期**: 2026-06-06  
+> **状态**: Draft  
+> **作者**: StarLotus + Claude
+
+---
+
+## 1. 背景与动机
+
+LumenX Studio 当前只支持"剧本 → 分镜 → 资产 → 视频 → 合成"的完整 pipeline 工作流。用户必须先创建项目、输入剧本，才能触达图像/视频生成能力。
+
+但大量真实场景不需要完整 pipeline：
+
+- 创作者想**快速试模型**：测试不同模型对同一 prompt 的效果差异
+- 创作者想**生成独立素材**：一张角色设计图、一段动态测试视频，没有剧本上下文
+- 创作者想**探索创意**：自由组合 prompt 和参考图，快速迭代，找到满意的视觉方向后再进入正式项目
+- 创作者在项目进行中想**补充素材**：临时需要一张道具图或一段转场视频，不想走完整 pipeline
+
+**Playground** 就是解决这个问题的模块——一个无项目上下文、纯粹的 AI 生成工具台。
+
+---
+
+## 2. 产品定位
+
+```
+LumenX 产品家族
+├── LumenX Studio       ← pipeline-first 漫剧/视频生产
+├── LumenX Atelier      ← graph-first 个人创作画布
+├── LumenX Playground   ← ★ 独立生成工具台（本 PRD）
+└── LumenX Core         ← 共享后端/模型路由/资产存储
+```
+
+**Playground 不是一个"产品"，是一个"工具模块"**。它是 LumenX 生态中最低门槛的入口：零配置、无项目、即开即用。生成的资产可以流向 Studio 或 Atelier。
+
+---
+
+## 3. 目标用户与场景
+
+| 用户类型 | 场景 | 价值 |
+|---------|------|------|
+| 新用户 | 首次进入 LumenX，想快速体验 AI 生成能力 | 降低上手门槛，30 秒内看到第一张 AI 生成图 |
+| 独立创作者 | 生成单独的角色设计图、场景概念图 | 不必创建项目即可产出素材 |
+| 视频创作者 | 快速测试不同视频模型的运动效果 | 对比 Seedance / Kling / Vidu 的差异 |
+| Studio 用户 | 项目中临时需要补充素材 | 在 Playground 生成后收藏到资产库，再在项目中引用 |
+| 模型探索者 | 同一 prompt 跑多个模型对比 | 批量抽卡，快速选出最佳模型 |
+
+---
+
+## 4. 功能规格
+
+### 4.1 生成能力（v1 全覆盖）
+
+| 模式 | 输入 | 输出 | 可用模型 |
+|------|------|------|---------|
+| **文生图 (t2i)** | prompt | 图片 | gpt-image-2, qwen-image-2.0-pro, wan2.2/2.5-t2i |
+| **图生图 (i2i)** | prompt + 参考图 | 图片 | gpt-image-2, qwen-image-2.0-pro, wan2.5-i2i |
+| **文生视频 (t2v)** | prompt | 视频 | seedance-2.0-t2v, happyhorse-1.0-t2v |
+| **图生视频 (i2v)** | prompt + 首帧图 | 视频 | kling-v3, seedance-2.0, vidu, wan2.x, pixverse, happyhorse |
+| **参考图视频 (r2v)** | prompt + 参考图 + 可选首帧 | 视频 | kling-v3, seedance-2.0, vidu, wan2.6, pixverse, happyhorse |
+| **视频编辑 (v2v)** | prompt + 源视频 | 视频 | happyhorse-1.0-video-edit |
+
+模型列表从 `config/model_catalog/generated/model_catalog.json` 动态读取，Playground 不硬编码模型 ID。
+
+### 4.2 批量生成（抽卡）
+
+- 用户可设置"生成数量"（1-4 张/条），一次生成多个候选
+- 候选结果以网格形式展示在结果画廊中
+- 每个候选可独立预览、下载、收藏、送入下一步
+
+### 4.3 Prompt 模板与历史
+
+**Prompt 历史**：
+- 自动记录每次生成使用的 prompt
+- 历史列表按时间倒序，支持搜索
+- 一键复制到当前输入框
+- 可将任意历史 prompt 存为模板
+
+**Prompt 模板**：
+- 用户可创建自定义模板（名称 + prompt 文本 + 可选的默认参数）
+- 模板列表支持分类管理（图像 / 视频 / 通用）
+- 一键套用模板到当前输入
+- 模板持久化存储于 `output/playground_templates.json`
+
+### 4.4 结果管理
+
+- 生成结果实时出现在右侧画廊
+- 持久化到 `output/playground_history.json`
+- 每个结果卡片的操作：
+  - **预览**：图片放大 / 视频播放（复用 LightboxProvider）
+  - **下载**：保存到本地
+  - **收藏到资产库**：打上 `source: playground` 标签存入共享资产库
+  - **生成视频**（仅图片结果）：一键切到 i2v 模式，自动填入首帧
+  - **删除**：从历史中移除
+
+### 4.5 资产库双向打通
+
+**Playground → 资产库**：
+- 结果卡片上"收藏到资产库"按钮
+- 收藏时可选择分类（角色/场景/道具/通用素材）
+- 资产库中标记来源为 `playground`
+
+**资产库 → Playground**：
+- 在 i2i / i2v / r2v / v2v 模式的媒体上传区
+- 除了本地上传，增加"从资产库选取"按钮
+- 打开资产库选择器（modal），可按分类筛选
+
+---
+
+## 5. UI/UX 设计
+
+### 5.1 入口
+
+- **首页卡片**：Home 页增加 Playground 入口卡片（与 Library、Settings 同级）
+- **导航**：顶部 breadcrumb 或侧边栏增加 Playground 入口
+- **路由**：`#/playground`
+
+### 5.2 布局（左右分栏）
+
+参考可灵（图2）的暗色分栏布局，融合 LumenX 的 glassmorphism 设计语言：
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  LumenX > Playground                                    │
+├──────────────────────────┬──────────────────────────────┤
+│                          │                              │
+│  ┌─ 模式 Tab ──────────┐ │   生成结果画廊               │
+│  │ 文生图 │ 图生图 │ ...│ │                              │
+│  └──────────────────────┘ │   ┌──────┐ ┌──────┐        │
+│                          │   │ 结果1 │ │ 结果2 │        │
+│  ┌─ 模型选择器 ────────┐ │   │      │ │      │        │
+│  │ ● Seedance 2.0  ▾  │ │   │ [预览]│ │ [预览]│        │
+│  └──────────────────────┘ │   │ [↗i2v]│ │ [★收] │        │
+│                          │   └──────┘ └──────┘        │
+│  ┌─ 媒体输入（按模式） ─┐ │                              │
+│  │ [+ 上传首帧图]      │ │   ┌──────┐ ┌──────┐        │
+│  │ [📁 从资产库选取]    │ │   │ 结果3 │ │ 结果4 │        │
+│  └──────────────────────┘ │   └──────┘ └──────┘        │
+│                          │                              │
+│  ┌─ Prompt 输入 ───────┐ │   ── 历史分割线 ──           │
+│  │                      │ │                              │
+│  │ [📋模板] [🕐历史]   │ │   ┌──────┐ ┌──────┐        │
+│  └──────────────────────┘ │   │ 旧结果 │ │ ...  │        │
+│                          │   └──────┘ └──────┘        │
+│  ┌─ 参数栏 ────────────┐ │                              │
+│  │ 16:9 ▾ │ 720P │ 5s  │ │                              │
+│  │ 数量: [1] [2] [4]   │ │                              │
+│  │ ▸ 高级参数           │ │                              │
+│  └──────────────────────┘ │                              │
+│                          │                              │
+│  [════ 生成 ════════════] │                              │
+│                          │                              │
+├──────────────────────────┴──────────────────────────────┤
+```
+
+### 5.3 设计规范
+
+- 遵循 LumenX 暗色主题（`#050508` 背景）
+- 面板使用 glassmorphism（5% white + backdrop-blur）
+- 主色 Electric Blue `#646cff`，强调色 Hot Pink `#ff0080`
+- 结果画廊使用 Framer Motion 的 staggered 入场动画
+- 模式 Tab 使用 LumenX 品牌渐变高亮
+- 生成中状态：卡片骨架屏 + 进度指示
+
+---
+
+## 6. 技术架构
+
+### 6.1 后端
+
+**新模块**：`src/apps/playground/`
+
+```
+src/apps/playground/
+├── __init__.py
+├── api.py              # FastAPI router（/playground/*）
+├── models.py           # Pydantic 数据模型
+├── service.py          # 生成编排逻辑
+└── storage.py          # 历史记录 & 模板持久化
+```
+
+**路由挂载**：在主 app 中 `app.include_router(playground_router, prefix="/playground")`
+
+**核心端点**：
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `POST` | `/playground/generate` | 统一生成入口 |
+| `GET` | `/playground/history` | 获取历史记录（分页） |
+| `GET` | `/playground/history/{id}` | 获取单条记录详情 |
+| `GET` | `/playground/history/{id}/status` | 轮询生成状态 |
+| `DELETE` | `/playground/history/{id}` | 删除历史记录 |
+| `POST` | `/playground/history/{id}/save-to-library` | 收藏到资产库 |
+| `GET` | `/playground/templates` | 获取模板列表 |
+| `POST` | `/playground/templates` | 创建模板 |
+| `PUT` | `/playground/templates/{id}` | 更新模板 |
+| `DELETE` | `/playground/templates/{id}` | 删除模板 |
+
+**生成流程**（`service.py`）：
+```
+POST /playground/generate
+  → 校验 mode + model_id + prompt
+  → 通过 factory.py 获取模型适配器
+  → 创建 PlaygroundGeneration 记录（status: pending）
+  → 启动后台任务调用模型适配器
+  → 返回 generation_id
+  → 客户端轮询 /status 直到 completed/failed
+```
+
+### 6.2 数据模型
+
+```python
+class PlaygroundMode(str, Enum):
+    T2I = "t2i"
+    I2I = "i2i"
+    T2V = "t2v"
+    I2V = "i2v"
+    R2V = "r2v"
+    V2V = "v2v"
+
+class PlaygroundGeneration(BaseModel):
+    id: str
+    mode: PlaygroundMode
+    model_id: str
+    prompt: str
+    negative_prompt: Optional[str] = None
+    input_media: List[str] = []         # 输入媒体文件路径
+    parameters: dict = {}               # 分辨率、时长、宽高比等
+    batch_size: int = 1                 # 生成数量
+    outputs: List[PlaygroundOutput] = []
+    status: str = "pending"             # pending / running / completed / failed
+    error: Optional[str] = None
+    created_at: str
+    saved_to_library: bool = False
+
+class PlaygroundOutput(BaseModel):
+    id: str
+    media_path: str                     # 生成结果文件路径
+    media_type: str                     # "image" | "video"
+    thumbnail_path: Optional[str] = None
+    saved_to_library: bool = False
+
+class PlaygroundTemplate(BaseModel):
+    id: str
+    name: str
+    category: str = "general"           # image / video / general
+    prompt: str
+    negative_prompt: Optional[str] = None
+    default_mode: Optional[PlaygroundMode] = None
+    default_model_id: Optional[str] = None
+    default_parameters: dict = {}
+    created_at: str
+    updated_at: str
+```
+
+**持久化文件**：
+- `output/playground_history.json` — 生成历史
+- `output/playground_templates.json` — Prompt 模板
+
+### 6.3 前端
+
+**新模块**：`frontend/src/components/modules/playground/`
+
+```
+frontend/src/components/modules/playground/
+├── PlaygroundPage.tsx          # 主页面（左右分栏）
+├── ModeSelector.tsx            # 模式切换 Tab
+├── InputPanel.tsx              # 左侧输入面板
+├── ModelSelector.tsx           # 模型选择器
+├── MediaInput.tsx              # 媒体输入区（上传 + 从资产库选取）
+├── PromptInput.tsx             # Prompt 输入框（含模板/历史按钮）
+├── ParameterBar.tsx            # 参数配置栏（常用 + 高级折叠）
+├── ResultGallery.tsx           # 右侧结果画廊
+├── ResultCard.tsx              # 单个结果卡片
+├── PromptTemplateModal.tsx     # 模板管理弹窗
+├── PromptHistoryDrawer.tsx     # 历史 Prompt 抽屉
+├── AssetPickerModal.tsx        # 从资产库选取素材弹窗
+└── usePlaygroundStore.ts       # Zustand store
+```
+
+**Store 结构**（`usePlaygroundStore.ts`）：
+```typescript
+interface PlaygroundState {
+  // 当前输入状态
+  mode: PlaygroundMode
+  modelId: string
+  prompt: string
+  negativePrompt: string
+  inputMedia: File[]
+  parameters: Record<string, any>
+  batchSize: number
+
+  // 模型偏好记忆（mode → modelId）
+  modelPreferences: Record<PlaygroundMode, string>
+
+  // 生成历史
+  history: PlaygroundGeneration[]
+
+  // 模板
+  templates: PlaygroundTemplate[]
+
+  // UI 状态
+  isGenerating: boolean
+  activeGenerationIds: string[]
+}
+```
+
+**API 客户端**：在 `frontend/src/lib/api.ts` 中新增 `playground` 命名空间的方法。
+
+### 6.4 生成结果存储
+
+```
+output/
+├── playground/                  # ★ Playground 专属输出目录
+│   ├── images/                  # 生成的图片
+│   └── videos/                  # 生成的视频
+├── playground_history.json      # 历史记录
+└── playground_templates.json    # 模板数据
+```
+
+---
+
+## 7. 资产库集成细节
+
+### 7.1 收藏到资产库
+
+用户点击结果卡片的"收藏"按钮时：
+1. 调用 `POST /playground/history/{id}/save-to-library`
+2. 后端将文件复制/移动到 `output/assets/` 对应目录
+3. 在资产库数据中创建条目，标记 `source: "playground"`、`playground_generation_id`
+4. 前端更新 `saved_to_library` 状态，按钮变为已收藏样式
+
+### 7.2 从资产库选取
+
+在需要媒体输入的模式（i2i / i2v / r2v / v2v）：
+1. 输入区显示"从资产库选取"按钮
+2. 点击打开 `AssetPickerModal`
+3. Modal 内复用资产库的筛选/浏览逻辑
+4. 选中后将资产路径填入输入区
+
+---
+
+## 8. 实施计划
+
+### Phase 1 — 核心骨架（可跑通）
+1. 后端 `src/apps/playground/` 模块搭建 + `/playground/generate` + `/playground/history`
+2. 前端 `PlaygroundPage` 左右分栏 + `ModeSelector` + `PromptInput` + `ModelSelector`
+3. 实现 t2i 模式完整链路（prompt → 生成 → 结果展示）
+4. `#/playground` 路由注册 + 首页入口卡片
+5. 验证：能通过 Playground 生成一张图并看到结果
+
+### Phase 2 — 全模式 + 批量
+6. 补全 i2i / t2v / i2v / r2v / v2v 模式的输入面板和参数适配
+7. 批量生成（抽卡）功能
+8. `MediaInput` 组件（本地上传 + 文件预览）
+9. `ParameterBar`（常用参数 + 高级折叠）
+10. 验证：所有 6 种模式可正常生成
+
+### Phase 3 — 结果管理 + 资产库
+11. `ResultCard` 操作按钮（预览/下载/收藏/生成视频）
+12. 图→视频一键衔接流程
+13. 收藏到资产库 API + 前端集成
+14. 从资产库选取素材 `AssetPickerModal`
+15. 验证：t2i 生成图 → 收藏 → 在 i2v 中从资产库选取该图 → 生成视频
+
+### Phase 4 — 模板与历史
+16. Prompt 历史记录（自动收集 + 搜索 + 一键复制）
+17. Prompt 模板 CRUD（创建/编辑/删除/套用）
+18. `PromptTemplateModal` + `PromptHistoryDrawer`
+19. 模型偏好记忆持久化
+20. 验证：创建模板 → 切换模式 → 套用模板 → 生成
+
+---
+
+## 9. 不做的事情（v1 边界）
+
+- **不做项目关联**：Playground 生成的资产不自动关联到任何 Studio 项目
+- **不做 Agent 模式**：不集成 Atelier 的 Agent 规划能力
+- **不做协作**：单用户使用，不考虑多用户共享历史
+- **不做计费/积分**：本地部署产品，不需要积分系统
+- **不做 prompt 智能优化**：v1 不集成 LLM 对 prompt 的自动润色（Studio 有此功能，Playground 后续可加）
+- **不做视频拼接/合成**：Playground 只做单次生成，不做多段视频合并
+
+---
+
+## 10. 成功指标
+
+| 指标 | 目标 |
+|------|------|
+| 首次生成耗时 | 进入 Playground → 看到第一个结果 < 60 秒（不含模型推理时间） |
+| 模式覆盖 | 6 种模式全部可用 |
+| 图→视频转化 | 一键衔接流程可用，无需手动切换+重新上传 |
+| 资产库打通 | 双向流通：收藏 + 选取 |

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -360,6 +360,7 @@
   "nav": {
     "workspace": "Workspace",
     "library": "Library",
+    "playground": "Playground",
     "settings": "Settings"
   },
   "workspace": {

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -360,6 +360,7 @@
   "nav": {
     "workspace": "工作区",
     "library": "主体库",
+    "playground": "创作台",
     "settings": "设置"
   },
   "workspace": {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import {
   Plus, FolderOpen, RefreshCw, Library, Calendar, Play, Trash2, FileUp, X, ChevronDown, FileText,
-  Zap, Film,
+  Zap, Film, Sparkles,
 } from "lucide-react";
 import { useProjectStore, Series, Project } from "@/store/projectStore";
 import ProjectCard from "@/components/project/ProjectCard";
@@ -23,6 +23,7 @@ const SeriesDetailPage = dynamic(() => import("@/components/series/SeriesDetailP
 const ImportFileDialog = dynamic(() => import("@/components/series/ImportFileDialog"), { ssr: false });
 const SettingsPage = dynamic(() => import("@/components/settings/SettingsPage"), { ssr: false });
 const AssetLibraryPage = dynamic(() => import("@/components/library/AssetLibraryPage"), { ssr: false });
+const PlaygroundPage = dynamic(() => import("@/components/modules/playground/PlaygroundPage"), { ssr: false });
 
 // ── Create Series Dialog ──
 function CreateSeriesDialog({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
@@ -470,7 +471,7 @@ export default function Home() {
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
   const [showCreateDropdown, setShowCreateDropdown] = useState(false);
-  const [currentView, setCurrentView] = useState<'home' | 'project' | 'series' | 'series-episode' | 'library' | 'settings'>('home');
+  const [currentView, setCurrentView] = useState<'home' | 'project' | 'series' | 'series-episode' | 'library' | 'settings' | 'playground'>('home');
   const [activeTab, setActiveTab] = useState<GlobalTab>("workspace");
   const [projectId, setProjectId] = useState<string | null>(null);
   const [seriesId, setSeriesId] = useState<string | null>(null);
@@ -602,6 +603,14 @@ export default function Home() {
         setEpisodeId(null);
         return;
       }
+      if (hash === '#/playground') {
+        setCurrentView('playground');
+        setActiveTab('playground');
+        setProjectId(null);
+        setSeriesId(null);
+        setEpisodeId(null);
+        return;
+      }
       // Default: workspace
       setCurrentView('home');
       setActiveTab('workspace');
@@ -654,6 +663,9 @@ export default function Home() {
     if (currentView === 'settings') {
       return <SettingsPage />;
     }
+    if (currentView === 'playground') {
+      return <PlaygroundPage />;
+    }
 
     // Workspace view
     return (
@@ -668,7 +680,7 @@ export default function Home() {
             <FolderOpen size={64} className="text-text-muted mb-4" />
             <h3 className="text-xl font-medium text-text-secondary mb-2">{t("empty")}</h3>
             <p className="text-text-muted mb-8">{t("emptyHint")}</p>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-xl w-full">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-3xl w-full">
               <button
                 onClick={() => setIsSeriesDialogOpen(true)}
                 className="glass-panel p-6 rounded-xl border border-blue-500/30 hover:border-blue-500/60 transition-all group text-left"
@@ -684,6 +696,14 @@ export default function Home() {
                 <FileText size={32} className="text-gray-400 mb-3" />
                 <h4 className="text-lg font-display font-bold text-foreground mb-1 group-hover:text-primary transition-colors">{t("createProject")}</h4>
                 <p className="text-sm text-text-secondary">{t("createProjectHint")}</p>
+              </button>
+              <button
+                onClick={() => { window.location.hash = '#/playground'; }}
+                className="glass-panel p-6 rounded-xl border border-purple-500/30 hover:border-purple-500/60 transition-all group text-left"
+              >
+                <Sparkles size={32} className="text-purple-400 mb-3" />
+                <h4 className="text-lg font-display font-bold text-foreground mb-1 group-hover:text-purple-400 transition-colors">Playground</h4>
+                <p className="text-sm text-text-secondary">{"独立生成"}</p>
               </button>
             </div>
             <button
@@ -746,6 +766,14 @@ export default function Home() {
                       >
                         <FileText size={16} className="text-gray-400" />
                         {t("newProject")}
+                      </button>
+                      <div className="border-t border-glass-border" />
+                      <button
+                        onClick={() => { window.location.hash = '#/playground'; setShowCreateDropdown(false); }}
+                        className="w-full px-4 py-2.5 text-sm text-left text-foreground hover:bg-hover-bg transition-colors flex items-center gap-2"
+                      >
+                        <Sparkles size={16} className="text-purple-400" />
+                        Playground
                       </button>
                     </motion.div>
                   )}

--- a/frontend/src/components/layout/GlobalSidebar.tsx
+++ b/frontend/src/components/layout/GlobalSidebar.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { FolderOpen, Library, Settings } from "lucide-react";
+import { FolderOpen, Library, Sparkles, Settings } from "lucide-react";
 import { useTranslations } from "next-intl";
 import clsx from "clsx";
 import LumenXBranding from "./LumenXBranding";
 
-export type GlobalTab = "workspace" | "library" | "settings";
+export type GlobalTab = "workspace" | "library" | "playground" | "settings";
 
 interface GlobalSidebarProps {
   activeTab: GlobalTab;
@@ -15,6 +15,7 @@ interface GlobalSidebarProps {
 const NAV_ITEMS: { id: GlobalTab; icon: typeof FolderOpen; hash: string }[] = [
   { id: "workspace", icon: FolderOpen, hash: "#/" },
   { id: "library", icon: Library, hash: "#/library" },
+  { id: "playground", icon: Sparkles, hash: "#/playground" },
   { id: "settings", icon: Settings, hash: "#/settings" },
 ];
 

--- a/frontend/src/components/modules/playground/AssetPickerModal.tsx
+++ b/frontend/src/components/modules/playground/AssetPickerModal.tsx
@@ -1,0 +1,438 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Check, Image, Film, Loader2 } from 'lucide-react';
+import { API_URL, playgroundApi } from '@/lib/api';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AssetPickerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (path: string) => void;
+  accept: 'image' | 'video' | 'all';
+}
+
+interface AssetItem {
+  id: string;
+  path: string;
+  type: 'image' | 'video';
+  thumbnail?: string;
+  label: string;
+}
+
+type FilterTab = 'all' | 'image' | 'video';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isVideoPath(path: string): boolean {
+  return /\.(mp4|mov|webm|avi|mkv)$/i.test(path);
+}
+
+function getFileName(path: string): string {
+  const parts = path.split('/');
+  return parts[parts.length - 1] || path;
+}
+
+/** Convert a media_path (e.g. "output/storyboard/foo.png") to a /files/ URL */
+function toFileUrl(mediaPath: string): string {
+  const relative = mediaPath.replace(/^output\//, '');
+  return API_URL + '/files/' + relative;
+}
+
+// ---------------------------------------------------------------------------
+// Animation
+// ---------------------------------------------------------------------------
+
+const overlayVariants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+};
+
+const modalVariants = {
+  hidden: { opacity: 0, scale: 0.95, y: 16 },
+  visible: { opacity: 1, scale: 1, y: 0 },
+};
+
+const springModal = { type: 'spring' as const, stiffness: 400, damping: 30 };
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function AssetPickerModal({
+  isOpen,
+  onClose,
+  onSelect,
+  accept,
+}: AssetPickerModalProps) {
+  const [assets, setAssets] = useState<AssetItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<FilterTab>(
+    accept === 'all' ? 'all' : accept
+  );
+
+  // -------------------------------------------------------------------------
+  // Fetch assets from playground history
+  // -------------------------------------------------------------------------
+
+  const fetchAssets = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const history = await playgroundApi.getHistory(100, 0);
+      const items: AssetItem[] = [];
+      const seen = new Set<string>();
+
+      for (const gen of history) {
+        if (gen.status !== 'completed') continue;
+        for (const output of gen.outputs) {
+          if (!output.media_path || seen.has(output.media_path)) continue;
+          seen.add(output.media_path);
+
+          const isVideo = isVideoPath(output.media_path);
+          items.push({
+            id: output.id,
+            path: output.media_path,
+            type: isVideo ? 'video' : 'image',
+            thumbnail: output.thumbnail_path || undefined,
+            label: getFileName(output.media_path),
+          });
+        }
+
+        // Also include input media from history entries
+        if (gen.input_media) {
+          for (const inputPath of gen.input_media) {
+            if (!inputPath || seen.has(inputPath)) continue;
+            seen.add(inputPath);
+
+            const isVideo = isVideoPath(inputPath);
+            items.push({
+              id: 'input-' + inputPath,
+              path: inputPath,
+              type: isVideo ? 'video' : 'image',
+              label: getFileName(inputPath),
+            });
+          }
+        }
+      }
+
+      setAssets(items);
+    } catch (err) {
+      console.error('[AssetPickerModal] fetch failed:', err);
+      setError('Failed to load assets');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelected(null);
+      fetchAssets();
+    }
+  }, [isOpen, fetchAssets]);
+
+  // Reset active tab when accept changes
+  useEffect(() => {
+    setActiveTab(accept === 'all' ? 'all' : accept);
+  }, [accept]);
+
+  // -------------------------------------------------------------------------
+  // Filter
+  // -------------------------------------------------------------------------
+
+  const filteredAssets = useMemo(() => {
+    // First filter by what the caller accepts
+    let pool = assets;
+    if (accept !== 'all') {
+      pool = pool.filter((a) => a.type === accept);
+    }
+    // Then by active tab
+    if (activeTab !== 'all') {
+      pool = pool.filter((a) => a.type === activeTab);
+    }
+    return pool;
+  }, [assets, accept, activeTab]);
+
+  // -------------------------------------------------------------------------
+  // Handlers
+  // -------------------------------------------------------------------------
+
+  const handleSelect = () => {
+    if (selected) {
+      onSelect(selected);
+      onClose();
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  // -------------------------------------------------------------------------
+  // Tab config
+  // -------------------------------------------------------------------------
+
+  const tabs: { key: FilterTab; label: string; icon: React.ReactNode; show: boolean }[] = [
+    {
+      key: 'all',
+      label: '全部',
+      icon: null,
+      show: accept === 'all',
+    },
+    {
+      key: 'image',
+      label: '图片',
+      icon: <Image className="w-3.5 h-3.5" />,
+      show: accept === 'all' || accept === 'image',
+    },
+    {
+      key: 'video',
+      label: '视频',
+      icon: <Film className="w-3.5 h-3.5" />,
+      show: accept === 'all' || accept === 'video',
+    },
+  ];
+
+  const visibleTabs = tabs.filter((t) => t.show);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          variants={overlayVariants}
+          initial="hidden"
+          animate="visible"
+          exit="hidden"
+          transition={{ duration: 0.2 }}
+          onClick={handleBackdropClick}
+        >
+          <motion.div
+            className="
+              w-[640px] max-h-[80vh]
+              bg-[#141416] border border-white/[0.08]
+              rounded-2xl shadow-2xl
+              flex flex-col overflow-hidden
+            "
+            variants={modalVariants}
+            initial="hidden"
+            animate="visible"
+            exit="hidden"
+            transition={springModal}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* -------------------------------------------------------------- */}
+            {/* Header                                                          */}
+            {/* -------------------------------------------------------------- */}
+            <div className="flex items-center justify-between px-5 pt-5 pb-3">
+              <h2 className="text-sm font-semibold text-white/90">
+                选择素材
+              </h2>
+
+              <button
+                type="button"
+                onClick={onClose}
+                className="
+                  w-7 h-7 rounded-lg flex items-center justify-center
+                  text-white/40 hover:text-white/80 hover:bg-white/[0.06]
+                  transition-colors
+                "
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* Filter tabs */}
+            {visibleTabs.length > 1 && (
+              <div className="flex items-center gap-1.5 px-5 pb-3">
+                {visibleTabs.map((tab) => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => setActiveTab(tab.key)}
+                    className={`
+                      flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs
+                      transition-colors
+                      ${
+                        activeTab === tab.key
+                          ? 'bg-[#646cff]/15 text-[#646cff] border border-[#646cff]/30'
+                          : 'text-white/50 hover:text-white/70 hover:bg-white/[0.04] border border-transparent'
+                      }
+                    `}
+                  >
+                    {tab.icon}
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* -------------------------------------------------------------- */}
+            {/* Grid                                                            */}
+            {/* -------------------------------------------------------------- */}
+            <div className="flex-1 overflow-y-auto px-5 pb-2 min-h-0">
+              {loading && (
+                <div className="flex flex-col items-center justify-center py-16 gap-3">
+                  <Loader2 className="w-6 h-6 text-white/30 animate-spin" />
+                  <span className="text-xs text-white/40">加载中...</span>
+                </div>
+              )}
+
+              {error && !loading && (
+                <div className="flex flex-col items-center justify-center py-16 gap-3">
+                  <span className="text-xs text-red-400/80">{error}</span>
+                  <button
+                    type="button"
+                    onClick={fetchAssets}
+                    className="text-xs text-[#646cff] hover:underline"
+                  >
+                    重试
+                  </button>
+                </div>
+              )}
+
+              {!loading && !error && filteredAssets.length === 0 && (
+                <div className="flex flex-col items-center justify-center py-16 gap-2">
+                  <Image className="w-8 h-8 text-white/20" />
+                  <span className="text-xs text-white/40">
+                    暂无可用素材
+                  </span>
+                  <span className="text-[11px] text-white/25">
+                    在 Playground 中生成内容后，输出将出现在这里
+                  </span>
+                </div>
+              )}
+
+              {!loading && !error && filteredAssets.length > 0 && (
+                <div className="grid grid-cols-4 gap-3">
+                  {filteredAssets.map((asset) => {
+                    const isSelected = selected === asset.path;
+                    const thumbUrl = asset.thumbnail
+                      ? toFileUrl(asset.thumbnail)
+                      : toFileUrl(asset.path);
+
+                    return (
+                      <button
+                        key={asset.id}
+                        type="button"
+                        onClick={() =>
+                          setSelected(isSelected ? null : asset.path)
+                        }
+                        className={`
+                          relative aspect-square rounded-lg overflow-hidden
+                          bg-white/[0.04] cursor-pointer
+                          transition-all duration-150
+                          ${
+                            isSelected
+                              ? 'border-2 border-[#646cff] ring-2 ring-[#646cff]/30'
+                              : 'border border-white/[0.04] hover:border-[#646cff]/50'
+                          }
+                        `}
+                      >
+                        {/* Thumbnail */}
+                        {asset.type === 'video' ? (
+                          <video
+                            src={thumbUrl}
+                            className="w-full h-full object-cover"
+                            muted
+                            preload="metadata"
+                          />
+                        ) : (
+                          <img
+                            src={thumbUrl}
+                            alt={asset.label}
+                            className="w-full h-full object-cover"
+                            loading="lazy"
+                          />
+                        )}
+
+                        {/* Type badge */}
+                        {asset.type === 'video' && (
+                          <div className="absolute top-1.5 left-1.5 px-1.5 py-0.5 rounded bg-black/60 backdrop-blur-sm">
+                            <Film className="w-3 h-3 text-white/70" />
+                          </div>
+                        )}
+
+                        {/* Selected checkmark */}
+                        {isSelected && (
+                          <div className="absolute top-1.5 right-1.5 w-5 h-5 rounded-full bg-[#646cff] flex items-center justify-center">
+                            <Check className="w-3 h-3 text-white" />
+                          </div>
+                        )}
+
+                        {/* File name */}
+                        <div className="absolute bottom-0 left-0 right-0 px-1.5 py-1 bg-gradient-to-t from-black/70 to-transparent">
+                          <span className="text-[10px] text-white/70 truncate block">
+                            {asset.label}
+                          </span>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* -------------------------------------------------------------- */}
+            {/* Footer                                                          */}
+            {/* -------------------------------------------------------------- */}
+            <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-white/[0.06]">
+              <button
+                type="button"
+                onClick={onClose}
+                className="
+                  px-4 py-2 rounded-lg text-xs
+                  text-white/60 hover:text-white/80
+                  hover:bg-white/[0.04]
+                  transition-colors
+                "
+              >
+                取消
+              </button>
+              <button
+                type="button"
+                onClick={handleSelect}
+                disabled={!selected}
+                className={`
+                  flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-medium
+                  transition-all
+                  ${
+                    selected
+                      ? 'bg-[#646cff] text-white hover:bg-[#545ae0] shadow-lg shadow-[#646cff]/20'
+                      : 'bg-white/[0.06] text-white/30 cursor-not-allowed'
+                  }
+                `}
+              >
+                <Check className="w-3.5 h-3.5" />
+                选择
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/modules/playground/DetailPanel.tsx
+++ b/frontend/src/components/modules/playground/DetailPanel.tsx
@@ -1,0 +1,405 @@
+'use client';
+
+import { useEffect, useCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  Download,
+  Star,
+  Video,
+  RotateCcw,
+  Trash2,
+  Copy,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
+import { API_URL, playgroundApi } from '@/lib/api';
+import { usePlaygroundStore, type PlaygroundGeneration } from './usePlaygroundStore';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface DetailPanelProps {
+  generation: PlaygroundGeneration;
+  allGenerations: PlaygroundGeneration[];
+  onClose: () => void;
+  onNavigate: (generation: PlaygroundGeneration) => void;
+  onRetry?: (generation: PlaygroundGeneration) => void;
+  onGenerateVideo?: (imagePath: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MODE_LABELS: Record<string, string> = {
+  t2v: 'T2V',
+  i2v: 'I2V',
+  r2v: 'R2V',
+  v2v: 'V2V',
+  t2i: 'T2I',
+  i2i: 'I2I',
+};
+
+function getMediaUrl(path: string): string {
+  const relativePath = path.replace(/^output\//, '');
+  return `${API_URL}/files/${relativePath}`;
+}
+
+function formatTimestamp(dateStr: string): string {
+  const date = new Date(dateStr);
+  const yyyy = date.getFullYear();
+  const MM = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  const ss = String(date.getSeconds()).padStart(2, '0');
+  return `${yyyy}-${MM}-${dd} ${hh}:${mm}:${ss}`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function DetailPanel({
+  generation: generationProp,
+  allGenerations,
+  onClose,
+  onNavigate,
+  onRetry,
+  onGenerateVideo,
+}: DetailPanelProps) {
+  const [copied, setCopied] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const updateGeneration = usePlaygroundStore((s) => s.updateGeneration);
+  const history = usePlaygroundStore((s) => s.history);
+
+  // Always read the latest generation from store (so saved_to_library stays in sync)
+  const generation = history.find((g) => g.id === generationProp.id) ?? generationProp;
+  const saved = generation.outputs[0]?.saved_to_library ?? false;
+
+  // Determine media
+  const output = generation.outputs[0];
+  const isVideo =
+    output?.media_type === 'video' ||
+    ['t2v', 'i2v', 'r2v', 'v2v'].includes(generation.mode);
+  const mediaUrl = output?.media_path ? getMediaUrl(output.media_path) : null;
+
+  // Navigation
+  const currentIndex = allGenerations.findIndex((g) => g.id === generation.id);
+  const hasPrev = currentIndex < allGenerations.length - 1;
+  const hasNext = currentIndex > 0;
+
+  const navigatePrev = useCallback(() => {
+    if (hasPrev) onNavigate(allGenerations[currentIndex + 1]);
+  }, [hasPrev, currentIndex, allGenerations, onNavigate]);
+
+  const navigateNext = useCallback(() => {
+    if (hasNext) onNavigate(allGenerations[currentIndex - 1]);
+  }, [hasNext, currentIndex, allGenerations, onNavigate]);
+
+  // Keyboard
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'ArrowLeft') navigatePrev();
+      if (e.key === 'ArrowRight') navigateNext();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose, navigatePrev, navigateNext]);
+
+  // Lock body scroll
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  // Actions
+  const handleCopyPrompt = () => {
+    navigator.clipboard.writeText(generation.prompt).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const handleDownload = () => {
+    if (!mediaUrl) return;
+    const a = document.createElement('a');
+    a.href = mediaUrl;
+    a.download = output?.media_path?.split('/').pop() || 'download';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  const handleSaveToLibrary = async () => {
+    if (!output || saving) return;
+    setSaving(true);
+    try {
+      const newSaved = !saved;
+      if (newSaved) {
+        await playgroundApi.saveToLibrary(generation.id, output.id);
+      }
+      const updatedOutputs = generation.outputs.map((o) =>
+        o.id === output.id ? { ...o, saved_to_library: newSaved } : o
+      );
+      updateGeneration({ ...generation, outputs: updatedOutputs });
+    } catch (err) {
+      console.error('[DetailPanel] Save to library failed:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      await playgroundApi.deleteGeneration(generation.id);
+      onClose();
+    } catch (err) {
+      console.error('[DetailPanel] Delete failed:', err);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  // Build parameter entries
+  const paramEntries: [string, string][] = [];
+  const params = generation.parameters || {};
+  if (params.size) paramEntries.push(['Size', params.size]);
+  if (params.resolution) paramEntries.push(['Resolution', params.resolution]);
+  if (params.aspect_ratio) paramEntries.push(['Aspect Ratio', params.aspect_ratio]);
+  if (params.duration) paramEntries.push(['Duration', `${params.duration}s`]);
+  if (generation.batch_size > 1)
+    paramEntries.push(['Batch Size', String(generation.batch_size)]);
+  if (params.seed !== undefined && params.seed !== null)
+    paramEntries.push(['Seed', String(params.seed)]);
+  // Add remaining params
+  const skipKeys = new Set([
+    'size',
+    'resolution',
+    'aspect_ratio',
+    'duration',
+    'seed',
+  ]);
+  Object.entries(params).forEach(([key, value]) => {
+    if (!skipKeys.has(key) && value !== undefined && value !== null && value !== '') {
+      paramEntries.push([key, String(value)]);
+    }
+  });
+
+  const modal = (
+    <>
+      {/* Overlay */}
+      <div
+        className="fixed inset-0 z-50 bg-black/90 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Container */}
+      <div className="fixed inset-4 md:inset-8 z-50 bg-[#0e0e11] border border-white/[0.06] rounded-2xl shadow-2xl flex overflow-hidden">
+        {/* ─── LEFT SIDE (Media) ─────────────────────────────────────────── */}
+        <div className="relative w-[60%] h-full bg-[#080809] flex items-center justify-center">
+          {mediaUrl ? (
+            isVideo ? (
+              <video
+                src={mediaUrl}
+                controls
+                className="max-w-full max-h-full object-contain rounded"
+              />
+            ) : (
+              <img
+                src={mediaUrl}
+                alt={generation.prompt}
+                className="max-w-full max-h-full object-contain"
+              />
+            )
+          ) : (
+            <div className="flex flex-col items-center gap-2 text-white/20">
+              <Video className="w-12 h-12" />
+              <span className="font-mono text-xs">No media</span>
+            </div>
+          )}
+
+          {/* Navigation arrows */}
+          {hasPrev && (
+            <button
+              onClick={navigatePrev}
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/[0.06] backdrop-blur-sm border border-white/[0.08] flex items-center justify-center hover:bg-white/[0.12] transition-colors"
+            >
+              <ChevronLeft className="w-5 h-5 text-white/70" />
+            </button>
+          )}
+          {hasNext && (
+            <button
+              onClick={navigateNext}
+              className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/[0.06] backdrop-blur-sm border border-white/[0.08] flex items-center justify-center hover:bg-white/[0.12] transition-colors"
+            >
+              <ChevronRight className="w-5 h-5 text-white/70" />
+            </button>
+          )}
+        </div>
+
+        {/* ─── RIGHT SIDE (Details) ──────────────────────────────────────── */}
+        <div className="relative w-[40%] h-full overflow-y-auto p-6 border-l border-white/[0.06]">
+          {/* Close button */}
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 w-8 h-8 rounded-lg bg-white/[0.04] border border-white/[0.08] flex items-center justify-center hover:bg-white/[0.10] transition-colors"
+          >
+            <X className="w-4 h-4 text-white/60" />
+          </button>
+
+          {/* Section 1: Title */}
+          <div className="mb-6 pr-10">
+            <h2 className="text-lg font-semibold text-white mb-1">
+              {generation.model_id}
+            </h2>
+            <div className="flex items-center gap-2 mb-1">
+              <span className="font-mono text-[10px] bg-white/[0.06] text-white/60 rounded px-[6px] py-[2px] uppercase">
+                {MODE_LABELS[generation.mode] || generation.mode}
+              </span>
+              <span className="font-mono text-[10px] text-white/30">
+                {generation.id.slice(0, 8)}
+              </span>
+            </div>
+            <p className="font-mono text-[11px] text-white/30">
+              {formatTimestamp(generation.created_at)}
+            </p>
+          </div>
+
+          {/* Section 2: Actions */}
+          <div className="flex flex-col gap-2 mb-6">
+            {mediaUrl && (
+              <button
+                onClick={handleDownload}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-white/[0.06] border border-white/[0.08] text-white/80 text-sm font-medium hover:bg-white/[0.10] transition-colors"
+              >
+                <Download className="w-4 h-4" />
+                Download
+              </button>
+            )}
+            {output && (
+              <button
+                onClick={handleSaveToLibrary}
+                disabled={saving}
+                className={`w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border text-sm font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-wait ${
+                  saved
+                    ? 'bg-white/[0.04] border-green-500/20 text-green-400 hover:border-white/[0.12] hover:text-white/60'
+                    : 'bg-white/[0.06] border-white/[0.08] text-white/80 hover:bg-white/[0.10]'
+                }`}
+              >
+                <Star
+                  className={`w-4 h-4 ${saved ? 'fill-green-400 text-green-400' : ''}`}
+                />
+                {saving ? '处理中...' : saved ? '已收藏（点击取消）' : '收藏到资产库'}
+              </button>
+            )}
+            {!isVideo && output?.media_path && onGenerateVideo && (
+              <button
+                onClick={() => onGenerateVideo(output.media_path)}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-[#646cff]/10 border border-[#646cff]/20 text-[#646cff] text-sm font-medium hover:bg-[#646cff]/20 transition-colors"
+              >
+                <Video className="w-4 h-4" />
+                Generate Video
+              </button>
+            )}
+            {generation.status === 'failed' && onRetry && (
+              <button
+                onClick={() => onRetry(generation)}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20 text-amber-400 text-sm font-medium hover:bg-amber-500/20 transition-colors"
+              >
+                <RotateCcw className="w-4 h-4" />
+                Retry
+              </button>
+            )}
+            <button
+              onClick={handleDelete}
+              disabled={deleting}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-red-500/[0.06] border border-red-500/[0.12] text-red-400/80 text-sm font-medium hover:bg-red-500/[0.12] transition-colors"
+            >
+              <Trash2 className="w-4 h-4" />
+              {deleting ? 'Deleting...' : 'Delete'}
+            </button>
+          </div>
+
+          {/* Section 3: Prompt */}
+          <div className="mb-6">
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="font-mono text-[10px] uppercase tracking-[0.18em] text-amber-500/80">
+                PROMPT
+              </h3>
+              <button
+                onClick={handleCopyPrompt}
+                className="flex items-center gap-1 px-2 py-1 rounded text-[10px] text-white/40 hover:text-white/60 hover:bg-white/[0.06] transition-colors"
+              >
+                <Copy className="w-3 h-3" />
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <div className="max-h-40 overflow-y-auto rounded-lg bg-white/[0.03] border border-white/[0.06] p-3">
+              <p className="text-[12px] text-white/70 leading-relaxed whitespace-pre-wrap break-words">
+                {generation.prompt || '(empty)'}
+              </p>
+            </div>
+          </div>
+
+          {/* Section 4: Parameters */}
+          {paramEntries.length > 0 && (
+            <div className="mb-6">
+              <h3 className="font-mono text-[10px] uppercase tracking-[0.18em] text-amber-500/80 mb-2">
+                参数
+              </h3>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+                {paramEntries.map(([label, value]) => (
+                  <div key={label}>
+                    <p className="text-[10px] text-white/40 mb-0.5">{label}</p>
+                    <p className="text-[12px] text-white font-mono truncate">
+                      {value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Section 5: Negative prompt */}
+          {generation.negative_prompt && (
+            <div className="mb-6">
+              <h3 className="font-mono text-[10px] uppercase tracking-[0.18em] text-amber-500/80 mb-2">
+                NEGATIVE PROMPT
+              </h3>
+              <div className="max-h-28 overflow-y-auto rounded-lg bg-white/[0.03] border border-white/[0.06] p-3">
+                <p className="text-[12px] text-white/50 leading-relaxed whitespace-pre-wrap break-words">
+                  {generation.negative_prompt}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Error display for failed generations */}
+          {generation.status === 'failed' && generation.error && (
+            <div className="mb-6">
+              <h3 className="font-mono text-[10px] uppercase tracking-[0.18em] text-red-400/80 mb-2">
+                ERROR
+              </h3>
+              <div className="max-h-28 overflow-y-auto rounded-lg bg-red-500/[0.04] border border-red-500/[0.12] p-3">
+                <p className="text-[11px] text-red-300/80 leading-relaxed break-all font-mono">
+                  {generation.error}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/frontend/src/components/modules/playground/GalleryView.tsx
+++ b/frontend/src/components/modules/playground/GalleryView.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Video, AlertCircle } from 'lucide-react';
+import { API_URL } from '@/lib/api';
+import type { PlaygroundGeneration } from './usePlaygroundStore';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface GalleryViewProps {
+  generations: PlaygroundGeneration[];
+  onOpenDetail: (gen: PlaygroundGeneration) => void;
+  onRetry?: (gen: PlaygroundGeneration) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getMediaUrl(path: string): string {
+  return API_URL + '/files/' + path.replace(/^output\//, '');
+}
+
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+const VIDEO_MODES = new Set(['t2v', 'i2v', 'r2v', 'v2v']);
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function GalleryView({
+  generations,
+  onOpenDetail,
+  onRetry,
+}: GalleryViewProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const thumbnailStripRef = useRef<HTMLDivElement>(null);
+
+  // Clamp selectedIndex when generations change
+  useEffect(() => {
+    if (selectedIndex >= generations.length) {
+      setSelectedIndex(Math.max(0, generations.length - 1));
+    }
+  }, [generations.length, selectedIndex]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        setSelectedIndex((prev) => Math.max(0, prev - 1));
+      } else if (e.key === 'ArrowRight') {
+        setSelectedIndex((prev) =>
+          Math.min(generations.length - 1, prev + 1)
+        );
+      } else if (e.key === 'Enter') {
+        if (generations[selectedIndex]) {
+          onOpenDetail(generations[selectedIndex]);
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [generations, selectedIndex, onOpenDetail]);
+
+  // Scroll selected thumbnail into view
+  useEffect(() => {
+    const strip = thumbnailStripRef.current;
+    if (!strip) return;
+    const thumb = strip.children[selectedIndex] as HTMLElement | undefined;
+    if (thumb) {
+      thumb.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  }, [selectedIndex]);
+
+  const handleClick = useCallback(() => {
+    if (generations[selectedIndex]) {
+      onOpenDetail(generations[selectedIndex]);
+    }
+  }, [generations, selectedIndex, onOpenDetail]);
+
+  if (generations.length === 0) {
+    return (
+      <div className="flex flex-col h-full items-center justify-center">
+        <p className="text-sm text-white/30">No results to display</p>
+      </div>
+    );
+  }
+
+  const current = generations[selectedIndex];
+  if (!current) return null;
+
+  const output = current.outputs[0];
+  const isVideo =
+    output?.media_type === 'video' || VIDEO_MODES.has(current.mode);
+  const mediaUrl = output?.media_path ? getMediaUrl(output.media_path) : null;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Main media area */}
+      <div
+        className="flex-1 flex items-center justify-center p-6 bg-[#050508]"
+        onClick={handleClick}
+      >
+        {current.status === 'completed' && mediaUrl ? (
+          isVideo ? (
+            <video
+              key={current.id}
+              src={mediaUrl}
+              controls
+              className="max-w-full max-h-full object-contain rounded-lg cursor-pointer hover:ring-2 hover:ring-[#646cff]/30 transition-all duration-200"
+            />
+          ) : (
+            <img
+              key={current.id}
+              src={mediaUrl}
+              alt={current.prompt}
+              className="max-w-full max-h-full object-contain rounded-lg cursor-pointer hover:scale-[1.01] hover:ring-2 hover:ring-[#646cff]/30 transition-all duration-200"
+            />
+          )
+        ) : current.status === 'failed' ? (
+          <div className="flex flex-col items-center gap-3 text-red-400/70">
+            <AlertCircle className="w-10 h-10" />
+            <p className="font-mono text-xs">Generation failed</p>
+            {current.error && (
+              <p className="text-[10px] text-white/30 max-w-xs text-center line-clamp-3">
+                {current.error}
+              </p>
+            )}
+            {onRetry && (
+              <button
+                onClick={() => onRetry(current)}
+                className="mt-2 px-3 py-1.5 rounded text-xs font-medium text-[#646cff] bg-[#646cff]/10 hover:bg-[#646cff]/20 transition-colors"
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-3 text-white/30">
+            <div className="w-8 h-8 border-2 border-white/10 border-t-[#646cff] rounded-full animate-spin" />
+            <p className="font-mono text-xs">
+              {current.status === 'pending' ? 'Queued...' : 'Generating...'}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Info bar */}
+      <div className="px-6 py-3 bg-[#0a0a0d] space-y-1.5">
+        <p className="text-xs text-white/50 line-clamp-2 leading-relaxed cursor-pointer hover:text-white/70 transition-colors" onClick={handleClick} title="点击查看详情">
+          {current.prompt || '(no prompt)'}
+        </p>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[9px] bg-white/[0.06] text-white/40 rounded px-[6px] py-[2px]">
+            {current.model_id || current.mode}
+          </span>
+          {current.parameters.size && (
+            <span className="font-mono text-[9px] bg-white/[0.04] text-white/30 rounded px-[6px] py-[2px]">
+              {(current.parameters.size as string).replace('*', '×').replace('x', '×')}
+            </span>
+          )}
+          {current.parameters.resolution && !current.parameters.size && (
+            <span className="font-mono text-[9px] bg-white/[0.04] text-white/30 rounded px-[6px] py-[2px]">
+              {current.parameters.resolution as string}
+            </span>
+          )}
+          <span className="font-mono text-[9px] text-white/30 ml-auto">
+            {formatTime(current.created_at)}
+          </span>
+        </div>
+      </div>
+
+      {/* Thumbnail strip */}
+      <div className="h-20 shrink-0 px-4 py-2 border-t border-white/[0.06] overflow-x-auto">
+        <div
+          ref={thumbnailStripRef}
+          className="flex gap-2 h-full items-center"
+        >
+          {generations.map((gen, idx) => {
+            const genOutput = gen.outputs[0];
+            const genIsVideo =
+              genOutput?.media_type === 'video' || VIDEO_MODES.has(gen.mode);
+            const genMediaUrl = genOutput?.media_path
+              ? getMediaUrl(genOutput.media_path)
+              : null;
+            const isSelected = idx === selectedIndex;
+            const isFailed = gen.status === 'failed';
+
+            return (
+              <button
+                key={gen.id}
+                onClick={() => setSelectedIndex(idx)}
+                className={`w-14 h-14 rounded-md overflow-hidden border-2 cursor-pointer shrink-0 transition-colors ${
+                  isSelected
+                    ? 'border-[#646cff]'
+                    : 'border-transparent hover:border-white/20'
+                }`}
+              >
+                {isFailed ? (
+                  <div className="w-full h-full bg-red-500/10 flex items-center justify-center">
+                    <AlertCircle className="w-4 h-4 text-red-400/60" />
+                  </div>
+                ) : genIsVideo ? (
+                  <div className="w-full h-full bg-gradient-to-br from-[#1a1a2e] to-[#0f0f1a] flex items-center justify-center">
+                    <Video className="w-4 h-4 text-white/30" />
+                  </div>
+                ) : genMediaUrl ? (
+                  <img
+                    src={genMediaUrl}
+                    alt=""
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-white/[0.04] flex items-center justify-center">
+                    <div className="w-3 h-3 border border-white/10 border-t-[#646cff] rounded-full animate-spin" />
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/MediaInput.tsx
+++ b/frontend/src/components/modules/playground/MediaInput.tsx
@@ -1,0 +1,423 @@
+'use client';
+
+import { useRef, useState, useCallback } from 'react';
+import { ImagePlus, Film, X } from 'lucide-react';
+import { playgroundApi } from '@/lib/api';
+import { usePlaygroundStore, type PlaygroundMode } from './usePlaygroundStore';
+import AssetPickerModal from './AssetPickerModal';
+
+// ---------------------------------------------------------------------------
+// Mode config
+// ---------------------------------------------------------------------------
+
+interface ModeConfig {
+  label: string;
+  accept: string;
+  hint: string;
+  multiple: boolean;
+  maxFiles: number;
+  icon: 'image' | 'video';
+}
+
+const MODE_CONFIG: Partial<Record<PlaygroundMode, ModeConfig>> = {
+  t2i: {
+    label: '参考图片（可选）',
+    accept: 'image/*',
+    hint: '上传参考图自动切换为图像编辑模式',
+    multiple: true,
+    maxFiles: 9,
+    icon: 'image',
+  },
+  i2i: {
+    label: '参考图片',
+    accept: 'image/*',
+    hint: '支持 JPG / PNG / WebP，建议尺寸不小于 512px',
+    multiple: false,
+    maxFiles: 1,
+    icon: 'image',
+  },
+  i2v: {
+    label: '首帧图片',
+    accept: 'image/*',
+    hint: '支持 JPG / PNG / WebP，建议尺寸不小于 720px',
+    multiple: false,
+    maxFiles: 1,
+    icon: 'image',
+  },
+  r2v: {
+    label: '参考图片',
+    accept: 'image/*',
+    hint: '支持 JPG / PNG / WebP，最多 9 张参考图',
+    multiple: true,
+    maxFiles: 9,
+    icon: 'image',
+  },
+  v2v: {
+    label: '源视频',
+    accept: 'video/*',
+    hint: '支持 MP4 / MOV / WebM',
+    multiple: false,
+    maxFiles: 1,
+    icon: 'video',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getFileName(path: string): string {
+  const parts = path.split('/');
+  return parts[parts.length - 1] || path;
+}
+
+function isVideoPath(path: string): boolean {
+  return /\.(mp4|mov|webm|avi|mkv)$/i.test(path);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function MediaInput() {
+  const mode = usePlaygroundStore((s) => s.mode);
+  const modelId = usePlaygroundStore((s) => s.modelId);
+  const inputMedia = usePlaygroundStore((s) => s.inputMedia);
+  const setInputMedia = usePlaygroundStore((s) => s.setInputMedia);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  const [showAssetPicker, setShowAssetPicker] = useState(false);
+
+  const isSeedance = modelId.startsWith('seedance');
+
+  let config = MODE_CONFIG[mode];
+
+  // Override r2v config when Seedance is selected
+  if (config && mode === 'r2v' && isSeedance) {
+    config = {
+      ...config,
+      label: '参考素材（图片/视频/音频）',
+      accept: 'image/*,video/*,audio/*',
+      hint: 'Seedance 支持图片、视频、音频作为参考素材',
+    };
+  }
+
+  // Don't render for t2v mode (no input media needed)
+  if (!config) return null;
+
+  const hasMedia = inputMedia.length > 0;
+  const canAddMore = config.multiple && inputMedia.length < config.maxFiles;
+
+  // -------------------------------------------------------------------------
+  // Upload handler
+  // -------------------------------------------------------------------------
+
+  const handleFiles = async (files: FileList | File[]) => {
+    const fileArray = Array.from(files);
+    if (fileArray.length === 0) return;
+
+    // Respect max file limit
+    const available = config.maxFiles - inputMedia.length;
+    const toUpload = fileArray.slice(0, available);
+
+    setUploading(true);
+    try {
+      const results = await Promise.all(
+        toUpload.map((file) => playgroundApi.uploadMedia(file))
+      );
+      const newPaths = results.map((r) => r.path);
+
+      if (config.multiple) {
+        setInputMedia([...inputMedia, ...newPaths]);
+      } else {
+        setInputMedia(newPaths);
+      }
+    } catch (err) {
+      console.error('[MediaInput] upload failed:', err);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  // -------------------------------------------------------------------------
+  // Event handlers
+  // -------------------------------------------------------------------------
+
+  const handleClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      handleFiles(e.target.files);
+    }
+    // Reset so re-selecting the same file works
+    e.target.value = '';
+  };
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setDragOver(false);
+      if (e.dataTransfer.files) {
+        handleFiles(e.dataTransfer.files);
+      }
+    },
+    [inputMedia, config]
+  );
+
+  const handleRemove = (index: number) => {
+    const updated = inputMedia.filter((_, i) => i !== index);
+    setInputMedia(updated);
+  };
+
+  const handleReplace = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleAssetSelect = (path: string) => {
+    setInputMedia([...inputMedia, path]);
+  };
+
+  // Determine accept type for AssetPickerModal
+  const acceptType: 'image' | 'video' | 'all' =
+    mode === 'r2v' && isSeedance
+      ? 'all'
+      : config.icon === 'video'
+        ? 'video'
+        : 'image';
+
+  // -------------------------------------------------------------------------
+  // Render: hidden file input
+  // -------------------------------------------------------------------------
+
+  const fileInput = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      accept={config.accept}
+      multiple={config.multiple}
+      onChange={handleFileChange}
+      className="hidden"
+    />
+  );
+
+  // -------------------------------------------------------------------------
+  // Render: empty state
+  // -------------------------------------------------------------------------
+
+  if (!hasMedia) {
+    return (
+      <div className="space-y-2">
+        <label className="block text-xs font-medium text-white/70">
+          {config.label}
+        </label>
+
+        <div
+          onClick={handleClick}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          className={`
+            border border-dashed rounded-xl p-6
+            flex flex-col items-center gap-3 text-center cursor-pointer
+            transition-colors
+            ${
+              dragOver
+                ? 'border-[#646cff]/50 bg-[#646cff]/5'
+                : 'border-white/[0.08] hover:border-white/15 hover:bg-white/[0.02]'
+            }
+            ${uploading ? 'pointer-events-none opacity-60' : ''}
+          `}
+        >
+          {config.icon === 'video' ? (
+            <Film className="w-8 h-8 text-white/40" />
+          ) : (
+            <ImagePlus className="w-8 h-8 text-white/40" />
+          )}
+
+          <span className="text-xs text-white/60">
+            {uploading ? '上传中...' : '拖拽或点击上传'}
+          </span>
+
+          <span className="text-[11px] text-white/40">{config.hint}</span>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleClick}
+            disabled={uploading}
+            className="
+              flex-1 px-3 py-1.5 rounded-lg text-xs
+              border border-white/[0.08] text-white/70
+              hover:bg-white/[0.04] hover:text-white/90
+              transition-colors disabled:opacity-40
+            "
+          >
+            本地上传
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowAssetPicker(true)}
+            className="
+              flex-1 px-3 py-1.5 rounded-lg text-xs
+              border border-[#646cff]/30 text-[#646cff]
+              hover:bg-[#646cff]/10
+              transition-colors
+            "
+          >
+            从资产库选取
+          </button>
+        </div>
+
+        {fileInput}
+
+        <AssetPickerModal
+          isOpen={showAssetPicker}
+          onClose={() => setShowAssetPicker(false)}
+          onSelect={handleAssetSelect}
+          accept={acceptType}
+        />
+      </div>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Render: has media state
+  // -------------------------------------------------------------------------
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-xs font-medium text-white/70">
+        {config.label}
+      </label>
+
+      <div className="border border-solid border-white/[0.08] rounded-xl p-3 space-y-3">
+        {/* Thumbnail row */}
+        <div className="flex flex-wrap gap-2">
+          {inputMedia.map((path, index) => (
+            <div
+              key={path + index}
+              className="group relative w-20 h-[60px] rounded-lg overflow-hidden bg-white/[0.04] border border-white/[0.06]"
+            >
+              {isVideoPath(path) ? (
+                <video
+                  src={path}
+                  className="w-full h-full object-cover"
+                  muted
+                />
+              ) : (
+                <img
+                  src={path}
+                  alt=""
+                  className="w-full h-full object-cover"
+                />
+              )}
+
+              {/* Remove button on hover */}
+              <button
+                type="button"
+                onClick={() => handleRemove(index)}
+                className="
+                  absolute top-0.5 right-0.5
+                  w-4 h-4 rounded-full
+                  bg-black/70 text-white/80
+                  flex items-center justify-center
+                  opacity-0 group-hover:opacity-100
+                  transition-opacity
+                "
+              >
+                <X className="w-3 h-3" />
+              </button>
+
+              {/* File name tooltip */}
+              <div className="absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/60 text-[9px] text-white/70 truncate">
+                {getFileName(path)}
+              </div>
+            </div>
+          ))}
+
+          {/* Add more button for r2v */}
+          {canAddMore && (
+            <button
+              type="button"
+              onClick={handleClick}
+              disabled={uploading}
+              className="
+                w-20 h-[60px] rounded-lg
+                border border-dashed border-white/[0.08]
+                flex items-center justify-center
+                text-white/30 hover:text-white/50 hover:border-white/15
+                transition-colors disabled:opacity-40
+              "
+            >
+              <ImagePlus className="w-5 h-5" />
+            </button>
+          )}
+        </div>
+
+        {/* File count for r2v */}
+        {config.multiple && (
+          <div className="text-[11px] text-white/40">
+            {inputMedia.length} / {config.maxFiles} 张
+          </div>
+        )}
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleReplace}
+          disabled={uploading}
+          className="
+            flex-1 px-3 py-1.5 rounded-lg text-xs
+            border border-white/[0.08] text-white/70
+            hover:bg-white/[0.04] hover:text-white/90
+            transition-colors disabled:opacity-40
+          "
+        >
+          {uploading ? '上传中...' : '替换文件'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowAssetPicker(true)}
+          className="
+            flex-1 px-3 py-1.5 rounded-lg text-xs
+            border border-[#646cff]/30 text-[#646cff]
+            hover:bg-[#646cff]/10
+            transition-colors
+          "
+        >
+          从资产库选取
+        </button>
+      </div>
+
+      {fileInput}
+
+      <AssetPickerModal
+        isOpen={showAssetPicker}
+        onClose={() => setShowAssetPicker(false)}
+        onSelect={handleAssetSelect}
+        accept={acceptType}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/ModeSelector.tsx
+++ b/frontend/src/components/modules/playground/ModeSelector.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Image, Film } from 'lucide-react';
+import { usePlaygroundStore, type PlaygroundMode } from './usePlaygroundStore';
+
+type Category = 'image' | 'video';
+
+const VIDEO_SUB_MODES: { key: PlaygroundMode; label: string }[] = [
+  { key: 't2v', label: '文生' },
+  { key: 'i2v', label: '图生' },
+  { key: 'r2v', label: '参考生' },
+  { key: 'v2v', label: '编辑' },
+];
+
+const IMAGE_MODE: PlaygroundMode = 't2i';
+
+function getCategory(mode: PlaygroundMode): Category {
+  return mode === 't2i' ? 'image' : 'video';
+}
+
+export default function ModeSelector() {
+  const mode = usePlaygroundStore((s) => s.mode);
+  const setMode = usePlaygroundStore((s) => s.setMode);
+
+  const category = getCategory(mode);
+
+  const handleCategoryChange = (cat: Category) => {
+    if (cat === 'image' && category !== 'image') {
+      setMode(IMAGE_MODE);
+    } else if (cat === 'video' && category !== 'video') {
+      setMode('i2v');
+    }
+  };
+
+  return (
+    <div className="space-y-2.5">
+      {/* Level 1: Category switch */}
+      <div className="flex gap-[2px] p-[3px] bg-white/[0.03] rounded-lg border border-white/[0.04]">
+        <button
+          type="button"
+          onClick={() => handleCategoryChange('image')}
+          className={[
+            'flex-1 flex items-center justify-center gap-2 py-2.5 rounded-md text-xs font-semibold cursor-pointer transition-all',
+            category === 'image'
+              ? 'text-white bg-[#646cff] shadow-[0_2px_8px_rgba(100,108,255,0.3)]'
+              : 'text-white/40 hover:text-white/60 hover:bg-white/[0.04]',
+          ].join(' ')}
+        >
+          <Image size={14} />
+          图像生成
+        </button>
+        <button
+          type="button"
+          onClick={() => handleCategoryChange('video')}
+          className={[
+            'flex-1 flex items-center justify-center gap-2 py-2.5 rounded-md text-xs font-semibold cursor-pointer transition-all',
+            category === 'video'
+              ? 'text-white bg-[#646cff] shadow-[0_2px_8px_rgba(100,108,255,0.3)]'
+              : 'text-white/40 hover:text-white/60 hover:bg-white/[0.04]',
+          ].join(' ')}
+        >
+          <Film size={14} />
+          视频生成
+        </button>
+      </div>
+
+      {/* Level 2: Video sub-mode pills (only when video category is active) */}
+      {category === 'video' && (
+        <div className="flex gap-[2px] p-[2px] bg-white/[0.02] rounded-md border border-white/[0.04]">
+          {VIDEO_SUB_MODES.map((m) => (
+            <button
+              key={m.key}
+              type="button"
+              onClick={() => setMode(m.key)}
+              className={[
+                'flex-1 py-[6px] rounded-md text-[11px] font-medium text-center cursor-pointer transition-all',
+                mode === m.key
+                  ? 'text-white bg-white/[0.1] border border-white/[0.08]'
+                  : 'text-white/35 hover:text-white/55 hover:bg-white/[0.03]',
+              ].join(' ')}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/ModelSelector.tsx
+++ b/frontend/src/components/modules/playground/ModelSelector.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { usePlaygroundStore } from './usePlaygroundStore';
+import { getModelsForMode, getModelDisplayInfo, type PlaygroundModelOption } from './playgroundModels';
+
+export default function ModelSelector() {
+  const mode = usePlaygroundStore((s) => s.mode);
+  const modelId = usePlaygroundStore((s) => s.modelId);
+  const setModelId = usePlaygroundStore((s) => s.setModelId);
+
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const availableModels = useMemo(() => getModelsForMode(mode), [mode]);
+
+  const selected = useMemo(() => {
+    const info = getModelDisplayInfo(modelId);
+    if (info) return info;
+    if (availableModels.length > 0) return { displayName: availableModels[0].displayName, family: availableModels[0].family };
+    return null;
+  }, [modelId, availableModels]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  useEffect(() => {
+    if (availableModels.length > 0 && !availableModels.some((m) => m.id === modelId)) {
+      setModelId(availableModels[0].id);
+    }
+  }, [availableModels, modelId, setModelId]);
+
+  function handleSelect(id: string) {
+    setModelId(id);
+    setOpen(false);
+  }
+
+  // Group models by family for visual grouping
+  const groupedModels = useMemo(() => {
+    const groups: { family: string; models: PlaygroundModelOption[] }[] = [];
+    let currentFamily = '';
+    for (const m of availableModels) {
+      if (m.family !== currentFamily) {
+        currentFamily = m.family;
+        groups.push({ family: currentFamily, models: [m] });
+      } else {
+        groups[groups.length - 1].models.push(m);
+      }
+    }
+    return groups;
+  }, [availableModels]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-[10px] px-[14px] py-[10px] border border-white/[0.08] rounded-lg bg-black/30 cursor-pointer w-full text-left transition-colors hover:border-white/[0.15]"
+      >
+        <span className="w-2 h-2 rounded-full bg-emerald-400 shrink-0" />
+        <span className="flex-1 text-[13px] font-medium text-white truncate">
+          {selected?.displayName ?? 'Select model'}
+        </span>
+        <span className="font-mono text-[10px] text-white/40 uppercase tracking-wider shrink-0">
+          {selected?.family ?? ''}
+        </span>
+        <span className="text-white/40 text-xs shrink-0">&#9662;</span>
+      </button>
+
+      {open && (
+        <div className="absolute top-full mt-1 w-full bg-[#141416] border border-white/[0.08] rounded-lg shadow-xl z-20 max-h-60 overflow-y-auto">
+          {availableModels.length === 0 && (
+            <div className="px-3 py-2 text-[12px] text-white/40">当前模式无可用模型</div>
+          )}
+          {groupedModels.map((group, gi) => (
+            <div key={group.family}>
+              {gi > 0 && <div className="border-t border-white/[0.04] mx-2" />}
+              {groupedModels.length > 1 && (
+                <div className="px-3 pt-2 pb-1">
+                  <span className="font-mono text-[9px] text-white/30 uppercase tracking-[0.15em]">
+                    {group.family}
+                  </span>
+                </div>
+              )}
+              {group.models.map((m) => (
+                <button
+                  key={m.id}
+                  type="button"
+                  onClick={() => handleSelect(m.id)}
+                  className={`flex items-center gap-[10px] w-full px-3 py-2 text-left transition-colors hover:bg-white/[0.06] ${
+                    m.id === modelId ? 'bg-white/[0.08] text-white' : 'text-white/80'
+                  }`}
+                >
+                  <span className="flex-1 text-[13px] font-medium truncate">
+                    {m.displayName}
+                  </span>
+                  {m.recommended && (
+                    <span className="text-[8px] font-mono text-[#646cff] bg-[#646cff]/10 px-1.5 py-0.5 rounded uppercase tracking-wider shrink-0">
+                      推荐
+                    </span>
+                  )}
+                  {m.id === modelId && (
+                    <span className="text-[#646cff] shrink-0">✓</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/ParameterBar.tsx
+++ b/frontend/src/components/modules/playground/ParameterBar.tsx
@@ -1,0 +1,508 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { usePlaygroundStore } from './usePlaygroundStore';
+import { getModelParams, getModelDuration } from './playgroundModels';
+import { ChevronDown, Check } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VIDEO_MODES = new Set(['t2v', 'i2v', 'r2v', 'v2v']);
+const BATCH_OPTIONS = [1, 2, 4] as const;
+
+const FALLBACK_RATIOS = ['16:9', '9:16', '1:1'];
+const FALLBACK_RESOLUTIONS = ['720P', '1080P'];
+
+// ---------------------------------------------------------------------------
+// ParamDropdown — custom styled dropdown (replaces native <select>)
+// ---------------------------------------------------------------------------
+
+/** Compute aspect ratio label from a "WxH" or "W*H" size string. */
+function sizeToRatioLabel(size: string): string | null {
+  const m = size.match(/^(\d+)[x*×](\d+)$/i);
+  if (!m) return null;
+  const w = parseInt(m[1], 10);
+  const h = parseInt(m[2], 10);
+  if (!w || !h) return null;
+  const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
+  const d = gcd(w, h);
+  return `${w / d}:${h / d}`;
+}
+
+function ParamDropdown({
+  label,
+  value,
+  options,
+  onChange,
+  disabled,
+  formatOption,
+}: {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  formatOption?: (opt: string) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const display = formatOption ?? ((o: string) => o);
+
+  return (
+    <div className="flex flex-col gap-[6px]">
+      <span className="text-[11px] font-medium text-white/40">{label}</span>
+      <div ref={containerRef} className="relative">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => !disabled && setOpen((o) => !o)}
+          className={`w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-white/[0.04] border border-white/[0.08] text-white text-xs font-medium transition cursor-pointer ${
+            disabled
+              ? 'opacity-50 cursor-not-allowed'
+              : 'hover:border-white/[0.15]'
+          }`}
+        >
+          <span>{display(value)}</span>
+          {!disabled && <ChevronDown className={`w-3 h-3 text-white/40 transition-transform ${open ? 'rotate-180' : ''}`} />}
+        </button>
+
+        {open && (
+          <div className="absolute top-full mt-1 w-full bg-[#141416] border border-white/[0.08] rounded-lg shadow-xl z-30 max-h-48 overflow-y-auto">
+            {options.map((opt) => (
+              <div
+                key={opt}
+                onClick={() => {
+                  onChange(opt);
+                  setOpen(false);
+                }}
+                className="px-3 py-2 text-xs flex items-center justify-between hover:bg-white/[0.06] cursor-pointer"
+              >
+                <span className={opt === value ? 'text-white' : 'text-white/60'}>
+                  {display(opt)}
+                </span>
+                {opt === value && <Check className="w-3 h-3 text-[#646cff]" />}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Format image size with aspect ratio: "1024x1024" → "1024×1024 (1:1)" */
+function formatImageSize(size: string): string {
+  const normalized = size.replace('*', '×').replace('x', '×');
+  const ratio = sizeToRatioLabel(size);
+  return ratio ? `${normalized} (${ratio})` : normalized;
+}
+
+// ---------------------------------------------------------------------------
+// PillToggle — ON / OFF pill selector
+// ---------------------------------------------------------------------------
+
+function PillToggle({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-[6px]">
+      <span className="text-[11px] font-medium text-white/40">{label}</span>
+      <div className="flex gap-0 p-[2px] bg-white/[0.03] rounded-lg border border-white/[0.04]">
+        <button
+          type="button"
+          onClick={() => onChange(true)}
+          className={`flex-1 px-3 py-[6px] rounded-md text-[11px] font-medium text-center cursor-pointer transition-all ${
+            value
+              ? 'bg-[#646cff] text-white shadow-[0_1px_4px_rgba(100,108,255,0.3)]'
+              : 'text-white/40 hover:text-white/60'
+          }`}
+        >
+          ON
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange(false)}
+          className={`flex-1 px-3 py-[6px] rounded-md text-[11px] font-medium text-center cursor-pointer transition-all ${
+            !value
+              ? 'bg-[#646cff] text-white shadow-[0_1px_4px_rgba(100,108,255,0.3)]'
+              : 'text-white/40 hover:text-white/60'
+          }`}
+        >
+          OFF
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DurationStepper — +/- stepper for integer seconds
+// ---------------------------------------------------------------------------
+
+function DurationStepper({
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.replace(/[^0-9]/g, '');
+    if (raw === '') return;
+    const num = parseInt(raw, 10);
+    onChange(Math.max(min, Math.min(max, num)));
+  };
+
+  const handleBlur = () => {
+    onChange(Math.max(min, Math.min(max, value)));
+  };
+
+  return (
+    <div className="flex flex-col gap-[6px]">
+      <span className="text-[11px] font-medium text-white/40">时长</span>
+      <div className="flex items-center gap-0 rounded-lg border border-white/[0.08] bg-white/[0.04] overflow-hidden">
+        <button
+          type="button"
+          disabled={value <= min}
+          onClick={() => onChange(Math.max(min, value - step))}
+          className="px-3 py-2.5 text-white/60 hover:text-white hover:bg-white/[0.06] transition disabled:opacity-30 disabled:cursor-not-allowed text-sm font-medium shrink-0"
+        >
+          −
+        </button>
+        <div className="flex-1 flex items-center justify-center gap-0.5 py-2.5">
+          <input
+            type="text"
+            inputMode="numeric"
+            value={value}
+            onChange={handleInputChange}
+            onBlur={handleBlur}
+            className="w-8 bg-transparent text-center font-mono text-xs font-medium text-white outline-none"
+          />
+          <span className="text-[10px] text-white/40 font-mono">s</span>
+        </div>
+        <button
+          type="button"
+          disabled={value >= max}
+          onClick={() => onChange(Math.min(max, value + step))}
+          className="px-3 py-2.5 text-white/60 hover:text-white hover:bg-white/[0.06] transition disabled:opacity-30 disabled:cursor-not-allowed text-sm font-medium shrink-0"
+        >
+          +
+        </button>
+      </div>
+      <div className="flex justify-between px-1">
+        <span className="text-[9px] text-white/20 font-mono">{min}s</span>
+        <span className="text-[9px] text-white/20 font-mono">{max}s</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ParameterBar
+// ---------------------------------------------------------------------------
+
+export default function ParameterBar() {
+  const mode = usePlaygroundStore((s) => s.mode);
+  const modelId = usePlaygroundStore((s) => s.modelId);
+  const parameters = usePlaygroundStore((s) => s.parameters);
+  const batchSize = usePlaygroundStore((s) => s.batchSize);
+  const setParameters = usePlaygroundStore((s) => s.setParameters);
+  const setBatchSize = usePlaygroundStore((s) => s.setBatchSize);
+
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const isVideoMode = VIDEO_MODES.has(mode);
+
+  // Read model-specific params and duration from catalog
+  const modelParams = getModelParams(modelId);
+  const modelDuration = getModelDuration(modelId);
+
+  // Derive options with fallbacks — IMAGE uses size, VIDEO uses resolution/ratio
+  const hasSize = !!modelParams?.size;
+  const hasResolution = !!modelParams?.resolution;
+  const hasRatio = !!modelParams?.ratio;
+  const hasQuality = !!modelParams?.quality;
+
+  const sizeOptions = modelParams?.size?.options ?? [];
+  const sizeDefault = modelParams?.size?.default ?? sizeOptions[0] ?? '1024*1024';
+  const ratioOptions = modelParams?.ratio?.options ?? FALLBACK_RATIOS;
+  const ratioDefault = modelParams?.ratio?.default ?? ratioOptions[0];
+  const resolutionOptions = modelParams?.resolution?.options ?? FALLBACK_RESOLUTIONS;
+  const resolutionDefault = modelParams?.resolution?.default ?? resolutionOptions[0];
+  const qualityOptions = modelParams?.quality?.options ?? [];
+  const qualityDefault = modelParams?.quality?.default ?? qualityOptions[0] ?? 'high';
+
+  // Boolean feature flags from model
+  const supportsSeed = modelParams?.seed !== false;
+  const supportsPromptExtend = modelParams?.promptExtend !== false;
+  const supportsWatermark = modelParams?.watermark !== false;
+  const hasAnyAdvanced = supportsSeed || supportsPromptExtend || supportsWatermark;
+
+  // When model changes, reset params whose current value is not in the new model's options
+  useEffect(() => {
+    const patches: Record<string, any> = {};
+
+    if (hasSize) {
+      const cur = parameters.size as string | undefined;
+      if (cur && !sizeOptions.includes(cur)) patches.size = sizeDefault;
+    }
+    if (hasRatio) {
+      const cur = parameters.aspect_ratio as string | undefined;
+      if (cur && !ratioOptions.includes(cur)) patches.aspect_ratio = ratioDefault;
+    }
+    if (hasResolution) {
+      const cur = parameters.resolution as string | undefined;
+      if (cur && !resolutionOptions.includes(cur)) patches.resolution = resolutionDefault;
+    }
+    if (hasQuality) {
+      const cur = parameters.quality as string | undefined;
+      if (cur && !qualityOptions.includes(cur)) patches.quality = qualityDefault;
+    }
+
+    if (isVideoMode && modelDuration) {
+      const currentDur = parameters.duration as number | undefined;
+      if (modelDuration.type === 'slider') {
+        if (currentDur != null && (currentDur < modelDuration.min || currentDur > modelDuration.max))
+          patches.duration = modelDuration.default;
+      } else if (modelDuration.type === 'buttons') {
+        if (currentDur != null && !modelDuration.options.includes(currentDur))
+          patches.duration = modelDuration.default;
+      } else if (modelDuration.type === 'fixed') {
+        patches.duration = modelDuration.value;
+      }
+    }
+
+    if (Object.keys(patches).length > 0) setParameters({ ...parameters, ...patches });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modelId]);
+
+  const updateParam = (key: string, value: any) => {
+    setParameters({ ...parameters, [key]: value });
+  };
+
+  // Duration state (video only)
+  const durationValue = (parameters.duration as number | undefined)
+    ?? (modelDuration?.type === 'fixed' ? modelDuration.value
+      : (modelDuration?.type === 'slider' || modelDuration?.type === 'buttons') ? modelDuration.default : 5);
+  const durationFixed = modelDuration?.type === 'fixed';
+
+  // Batch pill renderer (reused for both image and video)
+  const batchPills = (
+    <div className="flex flex-col gap-[6px]">
+      <span className="text-[11px] font-medium text-white/40">批量生成</span>
+      <div className="flex gap-0 p-[2px] bg-white/[0.03] rounded-lg border border-white/[0.04]">
+        {BATCH_OPTIONS.map((n) => (
+          <button
+            key={n}
+            type="button"
+            onClick={() => setBatchSize(n)}
+            className={`flex-1 py-[6px] rounded-md font-mono text-xs font-medium cursor-pointer transition-all text-center ${
+              batchSize === n
+                ? 'text-white bg-[#646cff] shadow-[0_1px_4px_rgba(100,108,255,0.3)]'
+                : 'text-white/40 hover:text-white/60'
+            }`}
+          >
+            x{n}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+
+        {/* ── IMAGE MODE PARAMS ── */}
+        {!isVideoMode && (
+          <>
+            {/* Size (image-specific, replaces resolution) */}
+            {hasSize && (
+              <ParamDropdown
+                label="图像尺寸"
+                value={(parameters.size as string) ?? sizeDefault}
+                options={sizeOptions}
+                onChange={(v) => updateParam('size', v)}
+                formatOption={formatImageSize}
+              />
+            )}
+
+            {/* Quality (GPT-Image-2 specific) */}
+            {hasQuality && (
+              <ParamDropdown
+                label="画质"
+                value={(parameters.quality as string) ?? qualityDefault}
+                options={qualityOptions}
+                onChange={(v) => updateParam('quality', v)}
+              />
+            )}
+
+            {/* Batch — spans full width if no quality, else single col */}
+            <div className={!hasQuality && !hasSize ? 'col-span-2' : hasSize && !hasQuality ? '' : ''}>
+              {batchPills}
+            </div>
+          </>
+        )}
+
+        {/* ── VIDEO MODE PARAMS ── */}
+        {isVideoMode && (
+          <>
+            {/* Ratio */}
+            {hasRatio && (
+              <ParamDropdown
+                label="画面比例"
+                value={(parameters.aspect_ratio as string) ?? ratioDefault}
+                options={ratioOptions}
+                onChange={(v) => updateParam('aspect_ratio', v)}
+              />
+            )}
+
+            {/* Resolution */}
+            {hasResolution && (
+              <ParamDropdown
+                label="分辨率"
+                value={(parameters.resolution as string) ?? resolutionDefault}
+                options={resolutionOptions}
+                onChange={(v) => updateParam('resolution', v)}
+              />
+            )}
+
+            {/* Fallback: show ratio + resolution even if model doesn't declare them */}
+            {!hasRatio && !hasResolution && (
+              <>
+                <ParamDropdown
+                  label="画面比例"
+                  value={(parameters.aspect_ratio as string) ?? FALLBACK_RATIOS[0]}
+                  options={FALLBACK_RATIOS}
+                  onChange={(v) => updateParam('aspect_ratio', v)}
+                />
+                <ParamDropdown
+                  label="分辨率"
+                  value={(parameters.resolution as string) ?? FALLBACK_RESOLUTIONS[0]}
+                  options={FALLBACK_RESOLUTIONS}
+                  onChange={(v) => updateParam('resolution', v)}
+                />
+              </>
+            )}
+
+            {/* Duration */}
+            {durationFixed ? (
+              <div className="flex flex-col gap-[6px]">
+                <span className="text-[11px] font-medium text-white/40">时长</span>
+                <div className="w-full flex items-center px-3 py-2.5 rounded-lg bg-white/[0.04] border border-white/[0.08] text-white/40 text-xs font-medium">
+                  {durationValue}s (固定)
+                </div>
+              </div>
+            ) : modelDuration?.type === 'buttons' ? (
+              <div className="flex flex-col gap-[6px]">
+                <span className="text-[11px] font-medium text-white/40">时长</span>
+                <div className="flex gap-0 p-[2px] bg-white/[0.03] rounded-lg border border-white/[0.04]">
+                  {modelDuration.options.map((n) => (
+                    <button
+                      key={n}
+                      type="button"
+                      onClick={() => updateParam('duration', n)}
+                      className={`flex-1 py-[6px] rounded-md font-mono text-xs font-medium cursor-pointer transition-all text-center ${
+                        durationValue === n
+                          ? 'text-white bg-[#646cff] shadow-[0_1px_4px_rgba(100,108,255,0.3)]'
+                          : 'text-white/40 hover:text-white/60'
+                      }`}
+                    >
+                      {n}s
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <DurationStepper
+                value={durationValue}
+                min={modelDuration?.type === 'slider' ? modelDuration.min : 1}
+                max={modelDuration?.type === 'slider' ? modelDuration.max : 15}
+                step={modelDuration?.type === 'slider' ? modelDuration.step : 1}
+                onChange={(v) => updateParam('duration', v)}
+              />
+            )}
+
+            {/* Batch */}
+            {batchPills}
+          </>
+        )}
+      </div>
+
+      {/* Advanced params — only show controls the model actually supports */}
+      {hasAnyAdvanced && (
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowAdvanced(!showAdvanced)}
+            className="text-[11px] font-medium text-white/40 hover:text-white/60 transition-colors cursor-pointer"
+          >
+            {showAdvanced ? '▾' : '▸'} 高级参数
+          </button>
+
+          {showAdvanced && (
+            <div className="grid grid-cols-2 gap-3 mt-3">
+              {supportsSeed && (
+                <div className="flex flex-col gap-[6px]">
+                  <span className="text-[11px] font-medium text-white/40">Seed</span>
+                  <input
+                    type="number"
+                    placeholder="随机"
+                    className="bg-white/[0.04] border border-white/[0.08] rounded-lg px-3 py-2.5 text-xs text-white font-mono w-full outline-none focus:border-white/[0.15] transition placeholder:text-white/20"
+                    value={parameters.seed ?? ''}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      updateParam('seed', val === '' ? undefined : parseInt(val) || undefined);
+                    }}
+                  />
+                </div>
+              )}
+
+              {supportsPromptExtend && (
+                <PillToggle
+                  label="提示词扩展"
+                  value={parameters.prompt_extend !== false}
+                  onChange={(v) => updateParam('prompt_extend', v)}
+                />
+              )}
+
+              {supportsWatermark && (
+                <PillToggle
+                  label="水印"
+                  value={parameters.watermark === true}
+                  onChange={(v) => updateParam('watermark', v)}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/PlaygroundPage.tsx
+++ b/frontend/src/components/modules/playground/PlaygroundPage.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import { useEffect, useCallback, useRef } from 'react';
+import ModeSelector from './ModeSelector';
+import ModelSelector from './ModelSelector';
+import MediaInput from './MediaInput';
+import PromptInput from './PromptInput';
+import ParameterBar from './ParameterBar';
+import ResultGallery from './ResultGallery';
+import { usePlaygroundStore, type PlaygroundMode, type PlaygroundGeneration } from './usePlaygroundStore';
+import { playgroundApi, type PlaygroundGenerationResponse } from '@/lib/api';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MODE_LABELS: Record<PlaygroundMode, string> = {
+  t2i: 'T2I',
+  i2i: 'I2I',
+  t2v: 'T2V',
+  i2v: 'I2V',
+  r2v: 'R2V',
+  v2v: 'V2V',
+};
+
+/** Modes that require media input (image or video source).
+ *  t2i also shows optional media input — when provided, it auto-becomes i2i. */
+const MODES_WITH_MEDIA: PlaygroundMode[] = ['i2i', 'i2v', 'r2v', 'v2v'];
+const MODES_WITH_OPTIONAL_MEDIA: PlaygroundMode[] = ['t2i'];
+
+/** Polling interval for generation status (ms) */
+const POLL_INTERVAL = 2000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert API response to store-compatible PlaygroundGeneration */
+function toGeneration(resp: PlaygroundGenerationResponse): PlaygroundGeneration {
+  return {
+    id: resp.id,
+    mode: resp.mode as PlaygroundMode,
+    model_id: resp.model_id,
+    prompt: resp.prompt,
+    negative_prompt: resp.negative_prompt,
+    input_media: resp.input_media,
+    parameters: resp.parameters,
+    batch_size: resp.batch_size,
+    outputs: resp.outputs.map((o) => ({
+      id: o.id,
+      media_path: o.media_path,
+      media_type: o.media_type as 'image' | 'video',
+      thumbnail_path: o.thumbnail_path,
+      saved_to_library: o.saved_to_library,
+    })),
+    status: resp.status as PlaygroundGeneration['status'],
+    error: resp.error,
+    created_at: resp.created_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function PlaygroundPage() {
+  const mode = usePlaygroundStore((s) => s.mode);
+  const modelId = usePlaygroundStore((s) => s.modelId);
+  const prompt = usePlaygroundStore((s) => s.prompt);
+  const negativePrompt = usePlaygroundStore((s) => s.negativePrompt);
+  const inputMedia = usePlaygroundStore((s) => s.inputMedia);
+  const parameters = usePlaygroundStore((s) => s.parameters);
+  const batchSize = usePlaygroundStore((s) => s.batchSize);
+  const history = usePlaygroundStore((s) => s.history);
+  const setHistory = usePlaygroundStore((s) => s.setHistory);
+  const setTemplates = usePlaygroundStore((s) => s.setTemplates);
+  const startGeneration = usePlaygroundStore((s) => s.startGeneration);
+  const updateGeneration = usePlaygroundStore((s) => s.updateGeneration);
+
+  const pollTimers = useRef<Map<string, ReturnType<typeof setInterval>>>(new Map());
+
+  // ─── Fetch initial data on mount ───────────────────────────────────────────
+
+  useEffect(() => {
+    playgroundApi.getHistory().then((items) => {
+      setHistory(items.map(toGeneration));
+    }).catch((err) => {
+      console.error('[Playground] Failed to fetch history:', err);
+    });
+
+    playgroundApi.getTemplates().then((items) => {
+      setTemplates(
+        items.map((t) => ({
+          id: t.id,
+          name: t.name,
+          category: t.category,
+          prompt: t.prompt,
+          negative_prompt: t.negative_prompt,
+          default_mode: t.default_mode as PlaygroundMode | undefined,
+          default_model_id: t.default_model_id,
+          default_parameters: t.default_parameters,
+          created_at: t.created_at,
+          updated_at: t.updated_at,
+        }))
+      );
+    }).catch((err) => {
+      console.error('[Playground] Failed to fetch templates:', err);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ─── Cleanup poll timers ───────────────────────────────────────────────────
+
+  useEffect(() => {
+    return () => {
+      pollTimers.current.forEach((timer) => clearInterval(timer));
+      pollTimers.current.clear();
+    };
+  }, []);
+
+  // ─── Status poller ─────────────────────────────────────────────────────────
+
+  const startPolling = useCallback((generationId: string) => {
+    // Prevent duplicate timers
+    if (pollTimers.current.has(generationId)) return;
+
+    const timer = setInterval(async () => {
+      try {
+        const statusResp = await playgroundApi.getGenerationStatus(generationId);
+        const isTerminal = statusResp.status === 'completed' || statusResp.status === 'failed';
+
+        // Fetch full generation data for complete update
+        const fullResp = await playgroundApi.getGeneration(generationId);
+        updateGeneration(toGeneration(fullResp));
+
+        if (isTerminal) {
+          clearInterval(timer);
+          pollTimers.current.delete(generationId);
+        }
+      } catch (err) {
+        console.error('[Playground] Poll failed for', generationId, err);
+        clearInterval(timer);
+        pollTimers.current.delete(generationId);
+      }
+    }, POLL_INTERVAL);
+
+    pollTimers.current.set(generationId, timer);
+  }, [updateGeneration]);
+
+  // ─── Generate handler ──────────────────────────────────────────────────────
+
+  const handleGenerate = useCallback(async () => {
+    if (!prompt.trim()) return;
+
+    try {
+      // Auto-detect i2i: if user is in "图像" tab (t2i) and has uploaded reference images, switch to i2i
+      const effectiveMode = (mode === 't2i' && inputMedia.length > 0) ? 'i2i' : mode;
+      const resp = await playgroundApi.generate({
+        mode: effectiveMode,
+        model_id: modelId,
+        prompt: prompt.trim(),
+        negative_prompt: negativePrompt || undefined,
+        input_media: inputMedia.length > 0 ? inputMedia : undefined,
+        parameters: Object.keys(parameters).length > 0 ? parameters : undefined,
+        batch_size: batchSize > 1 ? batchSize : undefined,
+      });
+
+      const gen = toGeneration(resp);
+      startGeneration(gen);
+
+      // Begin polling for status
+      if (gen.status !== 'completed' && gen.status !== 'failed') {
+        startPolling(gen.id);
+      }
+    } catch (err) {
+      console.error('[Playground] Generation request failed:', err);
+    }
+  }, [
+    mode, modelId, prompt, negativePrompt, inputMedia,
+    parameters, batchSize, startGeneration, startPolling,
+  ]);
+
+  // ─── Derived values ────────────────────────────────────────────────────────
+
+  const resultCount = history.length;
+  const showMediaInput = MODES_WITH_MEDIA.includes(mode) || MODES_WITH_OPTIONAL_MEDIA.includes(mode);
+  const canGenerate = prompt.trim().length > 0;
+  const generateLabel = batchSize > 1 ? `生成 ×${batchSize}` : '生成';
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-[#050508] text-white">
+      {/* ═══ PAGE HEADER ═══ */}
+      <header className="flex shrink-0 items-center justify-between border-b border-white/[0.04] px-7 py-5">
+        <div className="flex items-center">
+          <h1 className="font-['Space_Grotesk',sans-serif] text-xl font-semibold tracking-tight text-white">
+            创作台
+          </h1>
+          <span className="ml-[10px] font-mono text-[11px] uppercase tracking-[0.1em] text-white/40">
+            {resultCount} results
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="rounded border border-white/[0.08] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-white/40">
+            {MODE_LABELS[mode]}
+          </span>
+        </div>
+      </header>
+
+      {/* ═══ SPLIT LAYOUT ═══ */}
+      <div className="flex flex-1 overflow-hidden min-h-0">
+        {/* ─── LEFT: INPUT PANEL ─── */}
+        <aside className="flex w-[420px] shrink-0 flex-col overflow-y-auto border-r border-white/[0.08] bg-white/[0.02] scrollbar-thin">
+          {/* Mode */}
+          <section className="px-6 py-5">
+            <div className="mb-3 font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-white/40">
+              生成模式
+            </div>
+            <ModeSelector />
+          </section>
+
+          {/* Model */}
+          <section className="border-t border-white/[0.04] px-6 py-5">
+            <div className="mb-3 font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-white/40">
+              模型
+            </div>
+            <ModelSelector />
+          </section>
+
+          {/* Media Input (conditional) */}
+          {showMediaInput && (
+            <section className="border-t border-white/[0.04] px-6 py-5">
+              <div className="mb-3 font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-white/40">
+                {mode === 'v2v' ? '源视频' : mode === 'r2v' ? '参考素材' : '首帧图片'}
+              </div>
+              <MediaInput />
+            </section>
+          )}
+
+          {/* Prompt */}
+          <section className="border-t border-white/[0.04] px-6 py-5">
+            <div className="mb-3 font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-white/40">
+              Prompt
+            </div>
+            <PromptInput />
+          </section>
+
+          {/* Parameters */}
+          <section className="border-t border-white/[0.04] px-6 py-5">
+            <div className="mb-3 font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-white/40">
+              参数
+            </div>
+            <ParameterBar />
+          </section>
+
+          {/* Spacer to push generate button to bottom */}
+          <div className="flex-1" />
+
+          {/* Generate CTA (sticky) */}
+          <div className="sticky bottom-0 border-t border-white/[0.08] bg-[#050508] px-6 py-5">
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={!canGenerate}
+              className={[
+                'relative w-full overflow-hidden rounded-lg px-6 py-[14px]',
+                "font-['Space_Grotesk',sans-serif] text-sm font-semibold tracking-[0.02em] text-white",
+                'transition-all duration-150',
+                canGenerate
+                  ? 'bg-[#646cff] hover:bg-[#535bf2] hover:shadow-[0_4px_20px_rgba(100,108,255,0.35)] active:scale-[0.98] cursor-pointer'
+                  : 'bg-[#646cff]/40 cursor-not-allowed',
+              ].join(' ')}
+            >
+              {/* Glow overlay */}
+              <span className="pointer-events-none absolute inset-0 bg-gradient-to-br from-purple-600/20 via-[#646cff]/10 to-pink-500/15 opacity-0 transition-opacity duration-250 group-hover:opacity-100" />
+              <span className="relative">{generateLabel}</span>
+            </button>
+          </div>
+        </aside>
+
+        {/* ─── RIGHT: RESULT GALLERY ─── */}
+        <main className="flex flex-1 flex-col overflow-hidden min-w-0">
+          <ResultGallery />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/PromptHistoryDrawer.tsx
+++ b/frontend/src/components/modules/playground/PromptHistoryDrawer.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
+import { X, Copy, BookmarkPlus, Search } from 'lucide-react';
+import { usePlaygroundStore } from './usePlaygroundStore';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MODE_LABELS: Record<string, string> = {
+  t2i: 'T2I',
+  i2i: 'I2I',
+  t2v: 'T2V',
+  i2v: 'I2V',
+  r2v: 'R2V',
+  v2v: 'V2V',
+};
+
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return '刚刚';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days} 天前`;
+  const months = Math.floor(days / 30);
+  return `${months} 个月前`;
+}
+
+// ---------------------------------------------------------------------------
+// Deduplicated history entry
+// ---------------------------------------------------------------------------
+
+interface HistoryEntry {
+  prompt: string;
+  mode: string;
+  model_id: string;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function PromptHistoryDrawer() {
+  const showHistoryDrawer = usePlaygroundStore((s) => s.showHistoryDrawer);
+  const setShowHistoryDrawer = usePlaygroundStore((s) => s.setShowHistoryDrawer);
+  const history = usePlaygroundStore((s) => s.history);
+  const setPrompt = usePlaygroundStore((s) => s.setPrompt);
+  const setShowTemplateModal = usePlaygroundStore((s) => s.setShowTemplateModal);
+
+  const [search, setSearch] = useState('');
+  const [visible, setVisible] = useState(false);
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  // Animate in after mount
+  useEffect(() => {
+    if (showHistoryDrawer) {
+      // Allow a frame for the DOM to render before sliding in
+      const raf = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(raf);
+    }
+    setVisible(false);
+  }, [showHistoryDrawer]);
+
+  // Close with animation
+  const handleClose = useCallback(() => {
+    setVisible(false);
+    // Wait for transition to finish before unmounting
+    setTimeout(() => setShowHistoryDrawer(false), 250);
+  }, [setShowHistoryDrawer]);
+
+  // Deduplicate by prompt text, keep the most recent occurrence (history is newest-first)
+  const deduplicated = useMemo<HistoryEntry[]>(() => {
+    const seen = new Set<string>();
+    const results: HistoryEntry[] = [];
+    for (const gen of history) {
+      const key = gen.prompt.trim();
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      results.push({
+        prompt: gen.prompt,
+        mode: gen.mode,
+        model_id: gen.model_id,
+        created_at: gen.created_at,
+      });
+    }
+    return results;
+  }, [history]);
+
+  // Filter by search query
+  const filtered = useMemo(() => {
+    if (!search.trim()) return deduplicated;
+    const q = search.trim().toLowerCase();
+    return deduplicated.filter((e) => e.prompt.toLowerCase().includes(q));
+  }, [deduplicated, search]);
+
+  const handleCopy = useCallback(
+    (prompt: string) => {
+      setPrompt(prompt);
+      handleClose();
+    },
+    [setPrompt, handleClose],
+  );
+
+  const handleSaveAsTemplate = useCallback(
+    (prompt: string) => {
+      setPrompt(prompt);
+      setShowTemplateModal(true);
+      handleClose();
+    },
+    [setPrompt, setShowTemplateModal, handleClose],
+  );
+
+  if (!showHistoryDrawer) return null;
+
+  return (
+    // Overlay
+    <div
+      className="fixed inset-0 z-50 bg-black/60 transition-opacity duration-250"
+      style={{ opacity: visible ? 1 : 0 }}
+      onClick={handleClose}
+    >
+      {/* Drawer */}
+      <div
+        ref={drawerRef}
+        className="fixed right-0 top-0 h-full w-[400px] bg-[#141416] border-l border-white/[0.08] shadow-2xl flex flex-col transition-transform duration-250 ease-out"
+        style={{ transform: visible ? 'translateX(0)' : 'translateX(100%)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ── Header ─────────────────────────────────────────────────── */}
+        <div className="px-5 py-4 border-b border-white/[0.04] flex items-center justify-between shrink-0">
+          <h2 className="text-sm font-medium text-white/90">Prompt 历史</h2>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="w-7 h-7 rounded-md flex items-center justify-center text-white/40 hover:text-white/70 hover:bg-white/[0.06] transition-colors cursor-pointer"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* ── Search ─────────────────────────────────────────────────── */}
+        <div className="px-5 py-3 shrink-0">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30 pointer-events-none" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="搜索历史 prompt..."
+              className="w-full bg-white/[0.04] border border-white/[0.06] rounded-lg pl-9 pr-3 py-2 text-xs text-white/80 placeholder:text-white/25 outline-none focus:border-white/[0.12] transition-colors"
+            />
+          </div>
+        </div>
+
+        {/* ── List ───────────────────────────────────────────────────── */}
+        <div className="flex-1 overflow-y-auto px-5 py-2">
+          {filtered.length === 0 ? (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-xs text-white/25">
+                {search.trim() ? '无匹配结果' : '暂无生成历史'}
+              </p>
+            </div>
+          ) : (
+            filtered.map((entry, idx) => (
+              <div
+                key={`${entry.created_at}-${idx}`}
+                className={[
+                  'py-3',
+                  idx < filtered.length - 1
+                    ? 'border-b border-white/[0.04]'
+                    : '',
+                ].join(' ')}
+              >
+                {/* Prompt text */}
+                <p className="text-[12px] text-white/80 leading-relaxed line-clamp-3 mb-2">
+                  {entry.prompt}
+                </p>
+
+                {/* Meta row */}
+                <div className="flex items-center gap-1.5 mb-2">
+                  <span className="font-mono text-[9px] bg-[#646cff]/15 text-[#646cff] rounded px-[6px] py-[2px] uppercase">
+                    {MODE_LABELS[entry.mode] || entry.mode}
+                  </span>
+                  {entry.model_id && (
+                    <span className="font-mono text-[9px] bg-white/[0.04] text-white/40 rounded px-[6px] py-[2px]">
+                      {entry.model_id}
+                    </span>
+                  )}
+                  <span className="font-mono text-[9px] text-white/25 ml-auto">
+                    {relativeTime(entry.created_at)}
+                  </span>
+                </div>
+
+                {/* Actions row */}
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(entry.prompt)}
+                    className="flex items-center gap-1 text-[11px] text-white/40 hover:text-white/70 transition-colors cursor-pointer"
+                  >
+                    <Copy className="w-3 h-3" />
+                    复制
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleSaveAsTemplate(entry.prompt)}
+                    className="flex items-center gap-1 text-[11px] text-white/40 hover:text-white/70 transition-colors cursor-pointer"
+                  >
+                    <BookmarkPlus className="w-3 h-3" />
+                    存为模板
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/PromptInput.tsx
+++ b/frontend/src/components/modules/playground/PromptInput.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { Copy, Clock } from 'lucide-react';
+import { usePlaygroundStore } from './usePlaygroundStore';
+import PromptTemplateModal from './PromptTemplateModal';
+import PromptHistoryDrawer from './PromptHistoryDrawer';
+
+const MAX_LENGTH = 2000;
+
+export default function PromptInput() {
+  const prompt = usePlaygroundStore((s) => s.prompt);
+  const negativePrompt = usePlaygroundStore((s) => s.negativePrompt);
+  const setPrompt = usePlaygroundStore((s) => s.setPrompt);
+  const setNegativePrompt = usePlaygroundStore((s) => s.setNegativePrompt);
+  const setShowTemplateModal = usePlaygroundStore((s) => s.setShowTemplateModal);
+  const setShowHistoryDrawer = usePlaygroundStore((s) => s.setShowHistoryDrawer);
+
+  const [showNegPrompt, setShowNegPrompt] = useState(false);
+
+  return (
+    <div>
+      {/* Main prompt textarea */}
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value.slice(0, MAX_LENGTH))}
+        placeholder="描述你想生成的内容..."
+        className="w-full min-h-[120px] max-h-[280px] resize-y p-[14px] border border-white/[0.08] rounded-xl bg-black/30 text-white text-[13px] leading-relaxed placeholder-white/40 focus:border-[#646cff] focus:ring-[3px] focus:ring-[#646cff]/12 outline-none"
+      />
+
+      {/* Toolbar — below the textarea, not overlapping */}
+      <div className="flex items-center gap-[6px] mt-1.5 px-1">
+        <button
+          type="button"
+          onClick={() => setShowTemplateModal(true)}
+          className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium text-white/40 hover:text-white/60 hover:bg-white/[0.06] transition-colors"
+        >
+          <Copy size={12} />
+          模板
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowHistoryDrawer(true)}
+          className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium text-white/40 hover:text-white/60 hover:bg-white/[0.06] transition-colors"
+        >
+          <Clock size={12} />
+          历史
+        </button>
+        <span className="ml-auto font-mono text-[10px] text-white/30">
+          {prompt.length} / {MAX_LENGTH}
+        </span>
+      </div>
+
+      {/* Negative prompt toggle */}
+      <div
+        className="flex items-center gap-[6px] py-[6px] text-[11px] text-white/40 cursor-pointer hover:text-white/60 mt-2"
+        onClick={() => setShowNegPrompt((v) => !v)}
+      >
+        <span
+          className="inline-block transition-transform duration-150"
+          style={{ transform: showNegPrompt ? 'rotate(90deg)' : 'rotate(0deg)' }}
+        >
+          &#9656;
+        </span>
+        <span>负面提示词</span>
+      </div>
+
+      {showNegPrompt && (
+        <textarea
+          value={negativePrompt}
+          onChange={(e) => setNegativePrompt(e.target.value)}
+          placeholder="不希望出现的内容..."
+          className="w-full min-h-[60px] resize-y p-[10px] border border-white/[0.04] rounded-lg bg-black/30 text-white/60 text-xs placeholder-white/40 focus:border-[#646cff] focus:ring-[3px] focus:ring-[#646cff]/12 outline-none"
+        />
+      )}
+
+      <PromptTemplateModal />
+      <PromptHistoryDrawer />
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/PromptTemplateModal.tsx
+++ b/frontend/src/components/modules/playground/PromptTemplateModal.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { X, Plus, Copy, Trash2, Sparkles, BookmarkPlus, Star } from "lucide-react";
+import { playgroundApi } from "@/lib/api";
+import { usePlaygroundStore, type PlaygroundTemplate } from "./usePlaygroundStore";
+
+const CATEGORIES = [
+  { value: "image", label: "图像", color: "text-blue-400" },
+  { value: "video", label: "视频", color: "text-purple-400" },
+  { value: "general", label: "通用", color: "text-white/50" },
+] as const;
+
+type CategoryValue = (typeof CATEGORIES)[number]["value"];
+
+function categoryMeta(cat: string) {
+  return CATEGORIES.find((c) => c.value === cat) ?? CATEGORIES[2];
+}
+
+interface FormState {
+  name: string;
+  category: CategoryValue;
+  prompt: string;
+}
+
+const EMPTY_FORM: FormState = { name: "", category: "general", prompt: "" };
+
+export default function PromptTemplateModal() {
+  const {
+    templates,
+    showTemplateModal,
+    setShowTemplateModal,
+    applyTemplate,
+    removeTemplate,
+    addTemplate,
+    prompt: currentPrompt,
+    mode: currentMode,
+    modelId: currentModelId,
+    parameters: currentParams,
+    negativePrompt: currentNegativePrompt,
+    toggleTemplateFavorite,
+    isTemplateFavorited,
+  } = usePlaygroundStore();
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [busy, setBusy] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [filterCat, setFilterCat] = useState<CategoryValue | "all">("all");
+
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!showTemplateModal) return;
+    const t = window.setTimeout(() => dialogRef.current?.focus(), 0);
+    return () => window.clearTimeout(t);
+  }, [showTemplateModal]);
+
+  useEffect(() => {
+    if (!showTemplateModal) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.preventDefault(); setShowTemplateModal(false); }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [showTemplateModal, setShowTemplateModal]);
+
+  // Auto-open form with pre-filled prompt when modal opens with currentPrompt set
+  useEffect(() => {
+    if (showTemplateModal && currentPrompt.trim() && !formOpen) {
+      setForm({
+        name: "",
+        category: (currentMode === "t2i" || currentMode === "i2i") ? "image"
+          : (currentMode === "t2v" || currentMode === "i2v" || currentMode === "r2v" || currentMode === "v2v") ? "video"
+          : "general",
+        prompt: currentPrompt,
+      });
+      setFormOpen(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showTemplateModal]);
+
+  const handleApply = useCallback((tpl: PlaygroundTemplate) => {
+    applyTemplate(tpl);
+    setShowTemplateModal(false);
+  }, [applyTemplate, setShowTemplateModal]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    setDeletingId(id);
+    try { await playgroundApi.deleteTemplate(id); removeTemplate(id); } catch { /* silent */ }
+    finally { setDeletingId(null); }
+  }, [removeTemplate]);
+
+  const handleCreate = useCallback(async () => {
+    if (!form.name.trim() || !form.prompt.trim()) return;
+    setBusy(true);
+    try {
+      const created = await playgroundApi.createTemplate({
+        name: form.name.trim(),
+        category: form.category,
+        prompt: form.prompt.trim(),
+        negative_prompt: currentNegativePrompt || undefined,
+        default_mode: currentMode,
+        default_model_id: currentModelId || undefined,
+        default_parameters: Object.keys(currentParams).length > 0 ? currentParams : undefined,
+      });
+      addTemplate(created as unknown as PlaygroundTemplate);
+      setForm(EMPTY_FORM);
+      setFormOpen(false);
+    } catch { /* silent */ }
+    finally { setBusy(false); }
+  }, [form, addTemplate, currentMode, currentModelId, currentParams, currentNegativePrompt]);
+
+  const handlePrefill = useCallback(() => {
+    setForm({
+      name: "",
+      category: (currentMode === "t2i" || currentMode === "i2i") ? "image"
+        : (currentMode === "t2v" || currentMode === "i2v" || currentMode === "r2v" || currentMode === "v2v") ? "video"
+        : "general",
+      prompt: currentPrompt,
+    });
+    setFormOpen(true);
+  }, [currentPrompt, currentMode]);
+
+  if (!showTemplateModal || typeof window === "undefined") return null;
+
+  const filtered = (filterCat === "all"
+    ? templates
+    : templates.filter((t) => t.category === filterCat)
+  ).sort((a, b) => {
+    const aFav = isTemplateFavorited(a.id) ? 0 : 1;
+    const bFav = isTemplateFavorited(b.id) ? 0 : 1;
+    return aFav - bFav;
+  });
+
+  const modal = (
+    <>
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm"
+        onClick={() => setShowTemplateModal(false)}
+      />
+
+      <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          tabIndex={-1}
+          className="pointer-events-auto w-[560px] max-h-[85vh] bg-[#0e0e11] border border-white/[0.06] rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.8)] flex flex-col overflow-hidden outline-none"
+        >
+          {/* Header */}
+          <div className="px-6 py-5 border-b border-white/[0.06] flex items-center justify-between shrink-0">
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 rounded-lg bg-[#646cff]/15 flex items-center justify-center">
+                <BookmarkPlus size={16} className="text-[#646cff]" />
+              </div>
+              <div>
+                <h2 className="text-[15px] font-semibold text-white">Prompt 模板</h2>
+                <p className="text-[10px] text-white/30 mt-0.5">保存常用提示词，一键套用</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowTemplateModal(false)}
+              className="grid h-8 w-8 place-items-center rounded-lg text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60"
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          {/* Filter tabs */}
+          <div className="px-6 pt-4 pb-2 flex gap-1.5 shrink-0">
+            {[{ value: "all" as const, label: "全部" }, ...CATEGORIES].map((c) => (
+              <button
+                key={c.value}
+                type="button"
+                onClick={() => setFilterCat(c.value)}
+                className={[
+                  "px-3 py-1.5 rounded-md text-[11px] font-medium transition-all",
+                  filterCat === c.value
+                    ? "text-white bg-white/[0.08] border border-white/[0.08]"
+                    : "text-white/35 hover:text-white/55 hover:bg-white/[0.03] border border-transparent",
+                ].join(" ")}
+              >
+                {c.label}
+                {c.value !== "all" && (
+                  <span className="ml-1.5 text-[9px] text-white/20">
+                    {templates.filter((t) => t.category === c.value).length}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+
+          {/* Template list */}
+          <div className="flex-1 overflow-y-auto px-6 py-3 min-h-0 space-y-2">
+            {filtered.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <Sparkles size={28} className="text-white/10 mb-3" />
+                <p className="text-[13px] text-white/25 mb-1">
+                  {filterCat === "all" ? "暂无模板" : `暂无${categoryMeta(filterCat).label}模板`}
+                </p>
+                <p className="text-[11px] text-white/15">点击下方「新建」创建你的第一个模板</p>
+              </div>
+            )}
+
+            {filtered.map((tpl) => {
+              const meta = categoryMeta(tpl.category);
+              return (
+                <div
+                  key={tpl.id}
+                  className="group p-4 rounded-xl bg-white/[0.02] border border-white/[0.04] hover:border-white/[0.1] hover:bg-white/[0.03] transition-all"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1.5">
+                        <span className="text-[13px] font-medium text-white truncate">{tpl.name}</span>
+                        <span className={`text-[9px] font-mono uppercase px-1.5 py-[2px] rounded bg-white/[0.05] shrink-0 ${meta.color}`}>
+                          {meta.label}
+                        </span>
+                        {tpl.default_mode && (
+                          <span className="text-[9px] font-mono uppercase px-1.5 py-[2px] rounded bg-white/[0.04] text-white/25 shrink-0">
+                            {tpl.default_mode}
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-[11px] text-white/40 line-clamp-2 leading-[1.6]">{tpl.prompt}</p>
+                    </div>
+
+                    {/* Actions — visible on hover */}
+                    <div className="flex gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        type="button"
+                        onClick={() => toggleTemplateFavorite(tpl.id)}
+                        className={`h-7 w-7 rounded-md flex items-center justify-center transition-colors ${
+                          isTemplateFavorited(tpl.id)
+                            ? 'text-amber-400'
+                            : 'text-white/25 hover:text-amber-400/70'
+                        }`}
+                        title={isTemplateFavorited(tpl.id) ? '取消收藏' : '收藏'}
+                      >
+                        <Star size={12} className={isTemplateFavorited(tpl.id) ? 'fill-amber-400' : ''} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleApply(tpl)}
+                        className="h-7 px-2.5 rounded-md text-[11px] font-medium text-[#646cff] bg-[#646cff]/10 hover:bg-[#646cff]/20 transition-colors flex items-center gap-1"
+                      >
+                        <Copy size={11} />
+                        套用
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(tpl.id)}
+                        disabled={deletingId === tpl.id}
+                        className="h-7 w-7 rounded-md flex items-center justify-center text-white/25 hover:text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-30"
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Footer: create form */}
+          <div className="border-t border-white/[0.06] shrink-0">
+            {/* Toggle row */}
+            <div className="px-6 py-3 flex items-center">
+              {!formOpen ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setFormOpen(true)}
+                    className="inline-flex items-center gap-1.5 text-xs font-medium text-white/40 hover:text-white/60 transition-colors"
+                  >
+                    <Plus size={14} />
+                    新建模板
+                  </button>
+                  {currentPrompt.trim() && (
+                    <button
+                      type="button"
+                      onClick={handlePrefill}
+                      className="ml-auto inline-flex items-center gap-1.5 text-[11px] font-medium text-white/30 hover:text-white/50 transition-colors"
+                    >
+                      <Copy size={11} />
+                      从当前输入保存
+                    </button>
+                  )}
+                </>
+              ) : (
+                <>
+                  <span className="text-xs font-medium text-white/60">新建模板</span>
+                  <button
+                    type="button"
+                    onClick={() => { setFormOpen(false); setForm(EMPTY_FORM); }}
+                    className="ml-auto text-[11px] text-white/30 hover:text-white/50 transition-colors"
+                  >
+                    收起
+                  </button>
+                </>
+              )}
+            </div>
+
+            {/* Create form */}
+            {formOpen && (
+              <div className="px-6 pb-5 space-y-3">
+                {/* Name + Category row */}
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={form.name}
+                    onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                    placeholder="模板名称"
+                    className="flex-1 h-9 px-3 text-[13px] bg-white/[0.04] border border-white/[0.06] rounded-lg text-white placeholder:text-white/20 outline-none focus:border-[#646cff]/40 transition-colors"
+                    autoFocus
+                  />
+                </div>
+
+                {/* Category pills */}
+                <div className="flex gap-0 p-[2px] bg-white/[0.02] rounded-lg border border-white/[0.04]">
+                  {CATEGORIES.map((c) => (
+                    <button
+                      key={c.value}
+                      type="button"
+                      onClick={() => setForm((f) => ({ ...f, category: c.value as CategoryValue }))}
+                      className={[
+                        "flex-1 py-[6px] rounded-md text-[11px] font-medium text-center cursor-pointer transition-all",
+                        form.category === c.value
+                          ? "text-white bg-[#646cff] shadow-[0_1px_4px_rgba(100,108,255,0.3)]"
+                          : "text-white/35 hover:text-white/50",
+                      ].join(" ")}
+                    >
+                      {c.label}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Prompt */}
+                <textarea
+                  value={form.prompt}
+                  onChange={(e) => setForm((f) => ({ ...f, prompt: e.target.value }))}
+                  placeholder="输入 Prompt 内容..."
+                  rows={5}
+                  className="w-full min-h-[120px] px-3 py-2.5 text-[13px] leading-relaxed bg-white/[0.04] border border-white/[0.06] rounded-lg text-white placeholder:text-white/20 outline-none focus:border-[#646cff]/40 transition-colors resize-y"
+                />
+
+                {/* Submit */}
+                <button
+                  type="button"
+                  onClick={handleCreate}
+                  disabled={busy || !form.name.trim() || !form.prompt.trim()}
+                  className={[
+                    "w-full h-9 rounded-lg text-[13px] font-medium transition-all",
+                    form.name.trim() && form.prompt.trim()
+                      ? "bg-[#646cff] text-white hover:bg-[#535bf2] shadow-[0_2px_12px_rgba(100,108,255,0.25)]"
+                      : "bg-white/[0.04] text-white/20 cursor-not-allowed",
+                  ].join(" ")}
+                >
+                  {busy ? "保存中…" : "保存模板"}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/frontend/src/components/modules/playground/ResultCard.tsx
+++ b/frontend/src/components/modules/playground/ResultCard.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Download, Video, Star, Copy, Check } from 'lucide-react';
+import { API_URL, playgroundApi } from '@/lib/api';
+import { usePlaygroundStore, type PlaygroundGeneration } from './usePlaygroundStore';
+
+interface ResultCardProps {
+  generation: PlaygroundGeneration;
+  onGenerateVideo?: (imagePath: string) => void;
+  onRetry?: (generation: PlaygroundGeneration) => void;
+  onOpenDetail?: (generation: PlaygroundGeneration) => void;
+  onDelete?: (generation: PlaygroundGeneration) => void;
+}
+
+const MODE_LABELS: Record<string, string> = {
+  t2v: 'T2V',
+  i2v: 'I2V',
+  r2v: 'R2V',
+  v2v: 'V2V',
+  t2i: 'T2I',
+  i2i: 'I2I',
+};
+
+function getMediaUrl(path: string): string {
+  const relativePath = path.replace(/^output\//, '');
+  return `${API_URL}/files/${relativePath}`;
+}
+
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+function getElapsedProgress(createdAt: string): number {
+  const elapsed = Date.now() - new Date(createdAt).getTime();
+  // Estimate ~60s for generation, cap at 90%
+  const progress = Math.min(elapsed / 60000, 0.9);
+  return progress * 100;
+}
+
+function FailedCard({ generation, onRetry, onDelete }: { generation: PlaygroundGeneration; onRetry?: (g: PlaygroundGeneration) => void; onDelete?: (g: PlaygroundGeneration) => void }) {
+  const { prompt, model_id, mode, created_at, error } = generation;
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!error) return;
+    navigator.clipboard.writeText(error).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="rounded-xl border border-red-500/20 bg-white/[0.04] overflow-hidden">
+      <div
+        className="relative overflow-hidden bg-[#141416] flex flex-col items-center justify-center cursor-pointer"
+        style={{ aspectRatio: expanded ? undefined : '16/9', minHeight: expanded ? 120 : undefined }}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="absolute inset-0 bg-red-500/[0.05]" />
+        <div className="relative text-center px-4 py-3 w-full">
+          <p className="font-mono text-[10px] text-red-400/80 uppercase mb-2">生成失败</p>
+          {error && (
+            <p className={`text-[10px] text-white/40 leading-relaxed break-all ${expanded ? '' : 'line-clamp-2'}`}>
+              {error}
+            </p>
+          )}
+        </div>
+
+        {/* Action bar */}
+        <div className="relative flex items-center gap-2 pb-2">
+          {onRetry && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onRetry(generation); }}
+              className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[10px] font-medium text-[#646cff] bg-[#646cff]/10 hover:bg-[#646cff]/20 transition-colors"
+            >
+              ↻ 重试
+            </button>
+          )}
+          {onDelete && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onDelete(generation); }}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded text-[10px] font-medium text-red-400/60 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+            >
+              × 删除
+            </button>
+          )}
+          {error && (
+            <button
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded text-[10px] font-medium text-white/40 hover:text-white/60 hover:bg-white/[0.06] transition-colors"
+            >
+              {copied ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
+              {copied ? '已复制' : '复制全文'}
+            </button>
+          )}
+          <span className="text-[9px] text-white/20 ml-auto">
+            {expanded ? '收起' : '展开'}
+          </span>
+        </div>
+      </div>
+
+      <div className="px-3 py-[10px]">
+        <p className="text-[11px] text-white/60 line-clamp-2 mb-1.5">{prompt}</p>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[9px] bg-white/[0.04] text-white/40 rounded px-[6px] py-[2px]">
+            {model_id || mode}
+          </span>
+          <span className="font-mono text-[9px] text-white/30">
+            {formatTime(created_at)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CompletedCard({ generation, onGenerateVideo, onOpenDetail }: { generation: PlaygroundGeneration; onGenerateVideo?: (path: string) => void; onOpenDetail?: (generation: PlaygroundGeneration) => void }) {
+  const { prompt, model_id, mode, outputs, created_at } = generation;
+  const output = outputs[0];
+  const isVideo = output?.media_type === 'video' || ['t2v', 'i2v', 'r2v', 'v2v'].includes(mode);
+  const [saving, setSaving] = useState(false);
+
+  const saved = output?.saved_to_library ?? false;
+  const mediaUrl = output?.media_path ? getMediaUrl(output.media_path) : null;
+  const updateGeneration = usePlaygroundStore((s) => s.updateGeneration);
+
+  const handleDownload = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!mediaUrl) return;
+    try {
+      const resp = await fetch(mediaUrl);
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = output?.media_path?.split('/').pop() || 'download';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      window.open(mediaUrl, '_blank');
+    }
+  }, [mediaUrl, output]);
+
+  const handleSaveToLibrary = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!output || saving) return;
+    setSaving(true);
+    try {
+      const newSaved = !saved;
+      if (newSaved) {
+        await playgroundApi.saveToLibrary(generation.id, output.id);
+      }
+      const updatedOutputs = generation.outputs.map((o) =>
+        o.id === output.id ? { ...o, saved_to_library: newSaved } : o
+      );
+      updateGeneration({ ...generation, outputs: updatedOutputs });
+    } catch (err) {
+      console.error('[Playground] Save to library failed:', err);
+    } finally {
+      setSaving(false);
+    }
+  }, [generation, output, saved, saving, updateGeneration]);
+
+  return (
+    <div
+      className="group rounded-xl border border-white/[0.08] bg-white/[0.04] overflow-hidden hover:border-white/15 transition cursor-pointer"
+      onClick={() => onOpenDetail?.(generation)}
+    >
+      {/* Media area */}
+      <div className="relative overflow-hidden bg-[#141416]" style={{ aspectRatio: '16/9' }}>
+        {mediaUrl ? (
+          isVideo ? (
+            <div className="w-full h-full bg-gradient-to-br from-[#1a1a2e] to-[#0f0f1a] flex items-center justify-center">
+              <Video className="w-8 h-8 text-white/20" />
+            </div>
+          ) : (
+            <img src={mediaUrl} alt={prompt} className="w-full h-full object-cover" />
+          )
+        ) : (
+          <div className="w-full h-full bg-gradient-to-br from-[#1a1a2e] to-[#0f0f1a]" />
+        )}
+
+        {/* Video badge top-left */}
+        {isVideo && (
+          <span className="absolute top-2 left-2 font-mono text-[9px] bg-black/60 text-white/80 backdrop-blur-sm rounded px-[6px] py-[2px] uppercase">
+            {MODE_LABELS[mode] || mode}
+          </span>
+        )}
+
+        {/* Bottom gradient toolbar — appears on hover */}
+        <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-black/70 to-transparent flex items-end justify-end gap-1.5 px-3 pb-2.5 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            onClick={handleDownload}
+            className="w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm flex items-center justify-center hover:bg-white/25 transition"
+            title="下载"
+          >
+            <Download className="w-3.5 h-3.5 text-white" />
+          </button>
+          {output?.media_type === 'image' && onGenerateVideo && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onGenerateVideo(output.media_path); }}
+              className="w-7 h-7 rounded-full bg-white/10 backdrop-blur-sm flex items-center justify-center hover:bg-white/25 transition"
+              title="生成视频"
+            >
+              <Video className="w-3.5 h-3.5 text-white" />
+            </button>
+          )}
+          <button
+            onClick={handleSaveToLibrary}
+            className={`w-7 h-7 rounded-full backdrop-blur-sm flex items-center justify-center transition ${saved ? 'bg-green-500/20' : 'bg-white/10 hover:bg-white/25'}`}
+            title={saved ? '已收藏' : '收藏'}
+          >
+            <Star className={`w-3.5 h-3.5 ${saved ? 'text-green-400 fill-green-400' : 'text-white'}`} />
+          </button>
+        </div>
+      </div>
+
+      {/* Info area */}
+      <div className="px-3 py-[10px]">
+        <p className="text-[11px] text-white/60 line-clamp-2 mb-1.5">{prompt}</p>
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="font-mono text-[9px] bg-white/[0.04] text-white/40 rounded px-[6px] py-[2px]">
+            {model_id || mode}
+          </span>
+          {/* Size or resolution tag */}
+          {generation.parameters.size && (
+            <span className="font-mono text-[9px] bg-white/[0.04] text-white/30 rounded px-[6px] py-[2px]">
+              {(generation.parameters.size as string).replace('*', '×').replace('x', '×')}
+            </span>
+          )}
+          {generation.parameters.resolution && !generation.parameters.size && (
+            <span className="font-mono text-[9px] bg-white/[0.04] text-white/30 rounded px-[6px] py-[2px]">
+              {generation.parameters.resolution as string}
+            </span>
+          )}
+          {/* Mode badge */}
+          <span className="font-mono text-[9px] bg-[#646cff]/10 text-[#646cff]/70 rounded px-[6px] py-[2px] uppercase">
+            {MODE_LABELS[mode] || mode}
+          </span>
+          <span className="font-mono text-[9px] text-white/30 ml-auto">{formatTime(created_at)}</span>
+          {saved && (
+            <span className="flex items-center gap-0.5 text-[9px] text-green-400/70">
+              <Star className="w-2.5 h-2.5 fill-current" />
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ResultCard({ generation, onGenerateVideo, onRetry, onOpenDetail, onDelete }: ResultCardProps) {
+  const { status, prompt, model_id, mode, created_at } = generation;
+
+  // ─── PROCESSING STATE ───────────────────────────────────────────────────────
+  if (status === 'pending' || status === 'processing') {
+    return (
+      <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] overflow-hidden">
+        {/* Media area */}
+        <div className="relative overflow-hidden bg-[#141416]" style={{ aspectRatio: '16/9' }}>
+          {/* Skeleton shimmer */}
+          <div className="absolute inset-0 overflow-hidden">
+            <div
+              className="absolute inset-0 animate-shimmer"
+              style={{
+                background:
+                  'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.03) 50%, transparent 100%)',
+                backgroundSize: '200% 100%',
+              }}
+            />
+          </div>
+
+          {/* Centered spinner + text */}
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
+            <div className="w-6 h-6 border-2 border-white/10 border-t-[#646cff] rounded-full animate-spin" />
+            <span className="font-mono text-[10px] text-white/40 uppercase">
+              {status === 'pending' ? '排队中...' : '生成中...'}
+            </span>
+          </div>
+
+          {/* Progress bar */}
+          <div className="absolute bottom-0 left-0 right-0 h-[3px] bg-white/[0.04]">
+            <div
+              className="h-full bg-[#646cff] transition-all duration-1000 ease-out"
+              style={{ width: `${getElapsedProgress(created_at)}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Info area */}
+        <div className="px-3 py-[10px]">
+          <p className="text-[11px] text-white/60 line-clamp-2 mb-1.5">{prompt}</p>
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[9px] bg-white/[0.04] text-white/40 rounded px-[6px] py-[2px]">
+              {model_id || mode}
+            </span>
+            <span className="font-mono text-[9px] text-white/30">
+              {formatTime(created_at)}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── FAILED STATE ───────────────────────────────────────────────────────────
+  if (status === 'failed') {
+    return <FailedCard generation={generation} onRetry={onRetry} onDelete={onDelete} />;
+  }
+
+  // ─── COMPLETED STATE ────────────────────────────────────────────────────────
+  return <CompletedCard generation={generation} onGenerateVideo={onGenerateVideo} onOpenDetail={onOpenDetail} />;
+}

--- a/frontend/src/components/modules/playground/ResultGallery.tsx
+++ b/frontend/src/components/modules/playground/ResultGallery.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import { Sparkles, Grid3x3, GalleryHorizontal } from 'lucide-react';
+import { usePlaygroundStore, type PlaygroundGeneration } from './usePlaygroundStore';
+import { playgroundApi } from '@/lib/api';
+import ResultCard from './ResultCard';
+import GalleryView from './GalleryView';
+import DetailPanel from './DetailPanel';
+
+type FilterType = 'all' | 'image' | 'video';
+
+const VIDEO_MODES = new Set(['t2v', 'i2v', 'r2v', 'v2v']);
+
+function formatSessionLabel(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86400000);
+  const itemDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+
+  if (itemDay.getTime() === today.getTime()) {
+    return `今天 · ${hh}:${mm}`;
+  }
+  if (itemDay.getTime() === yesterday.getTime()) {
+    return `昨天 · ${hh}:${mm}`;
+  }
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${month}/${day} · ${hh}:${mm}`;
+}
+
+export default function ResultGallery() {
+  const { history, startGeneration, updateGeneration } = usePlaygroundStore();
+  const [activeFilter, setActiveFilter] = useState<FilterType>('all');
+  const [viewMode, setViewMode] = useState<'grid' | 'gallery'>('grid');
+  const [detailGen, setDetailGen] = useState<PlaygroundGeneration | null>(null);
+
+  const handleRetry = useCallback(async (gen: PlaygroundGeneration) => {
+    try {
+      const resp = await playgroundApi.generate({
+        mode: gen.mode,
+        model_id: gen.model_id,
+        prompt: gen.prompt,
+        negative_prompt: gen.negative_prompt || undefined,
+        input_media: gen.input_media.length > 0 ? gen.input_media : undefined,
+        parameters: Object.keys(gen.parameters).length > 0 ? gen.parameters : undefined,
+        batch_size: gen.batch_size > 1 ? gen.batch_size : undefined,
+      });
+      const newGen: PlaygroundGeneration = {
+        id: resp.id,
+        mode: resp.mode as PlaygroundGeneration['mode'],
+        model_id: resp.model_id,
+        prompt: resp.prompt,
+        negative_prompt: resp.negative_prompt,
+        input_media: resp.input_media,
+        parameters: resp.parameters,
+        batch_size: resp.batch_size,
+        outputs: [],
+        status: resp.status as PlaygroundGeneration['status'],
+        error: resp.error,
+        created_at: resp.created_at,
+      };
+      startGeneration(newGen);
+      // Poll for status
+      const poll = setInterval(async () => {
+        try {
+          const s = await playgroundApi.getGenerationStatus(newGen.id);
+          if (s.status === 'completed' || s.status === 'failed') {
+            clearInterval(poll);
+            const full = await playgroundApi.getGeneration(newGen.id);
+            updateGeneration({
+              ...newGen,
+              status: full.status as PlaygroundGeneration['status'],
+              outputs: full.outputs.map((o) => ({ id: o.id, media_path: o.media_path, media_type: o.media_type as 'image' | 'video', thumbnail_path: o.thumbnail_path, saved_to_library: o.saved_to_library })),
+              error: full.error,
+            });
+          }
+        } catch { clearInterval(poll); }
+      }, 2000);
+    } catch (err) {
+      console.error('[Playground] Retry failed:', err);
+    }
+  }, [startGeneration, updateGeneration]);
+
+  const handleDelete = useCallback(async (gen: PlaygroundGeneration) => {
+    try {
+      await playgroundApi.deleteGeneration(gen.id);
+      usePlaygroundStore.getState().removeGeneration(gen.id);
+    } catch (err) {
+      console.error('[Playground] Delete failed:', err);
+    }
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (activeFilter === 'all') return history;
+    if (activeFilter === 'image') {
+      return history.filter((g) => !VIDEO_MODES.has(g.mode));
+    }
+    return history.filter((g) => VIDEO_MODES.has(g.mode));
+  }, [history, activeFilter]);
+
+  // Sort descending by created_at
+  const sorted = useMemo(
+    () =>
+      [...filtered].sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      ),
+    [filtered],
+  );
+
+  // Build items with session dividers
+  const itemsWithDividers = useMemo(() => {
+    const result: Array<
+      | { type: 'generation'; data: PlaygroundGeneration }
+      | { type: 'divider'; label: string; key: string }
+    > = [];
+
+    for (let i = 0; i < sorted.length; i++) {
+      if (i > 0) {
+        const prevTime = new Date(sorted[i - 1].created_at).getTime();
+        const currTime = new Date(sorted[i].created_at).getTime();
+        const gap = prevTime - currTime; // prev is more recent (descending)
+        if (gap > 30 * 60 * 1000) {
+          result.push({
+            type: 'divider',
+            label: formatSessionLabel(sorted[i].created_at),
+            key: `divider-${sorted[i].id}`,
+          });
+        }
+      }
+      result.push({ type: 'generation', data: sorted[i] });
+    }
+
+    return result;
+  }, [sorted]);
+
+  // Flat list of generation data items (no dividers) for GalleryView and DetailPanel
+  const dataItems = useMemo(
+    () =>
+      itemsWithDividers
+        .filter((item): item is { type: 'generation'; data: PlaygroundGeneration } => item.type === 'generation')
+        .map((item) => item.data),
+    [itemsWithDividers],
+  );
+
+  const filters: { key: FilterType; label: string }[] = [
+    { key: 'all', label: '全部' },
+    { key: 'image', label: '图片' },
+    { key: 'video', label: '视频' },
+  ];
+
+  if (history.length === 0) {
+    return (
+      <div className="flex flex-col flex-1 overflow-hidden min-w-0 items-center justify-center">
+        <Sparkles className="w-12 h-12 text-white/40 opacity-40 mb-4" />
+        <p className="text-sm text-white/40 mb-1">暂无生成结果</p>
+        <p className="text-xs text-white/25">输入提示词并点击生成，结果将展示在这里</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col flex-1 overflow-hidden min-w-0">
+      {/* Header */}
+      <div className="px-7 py-4 flex items-center justify-between border-b border-white/[0.04] shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-white/40">
+            生成结果
+          </span>
+          <span className="font-mono text-[10px] bg-white/[0.06] text-white/50 rounded px-[6px] py-[1px]">
+            {filtered.length}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1 rounded-md bg-white/[0.04] p-[3px]">
+            {filters.map((f) => (
+              <button
+                key={f.key}
+                onClick={() => setActiveFilter(f.key)}
+                className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                  activeFilter === f.key
+                    ? 'bg-white/[0.08] text-white/80'
+                    : 'text-white/40 hover:text-white/60'
+                }`}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-0.5 rounded-md bg-white/[0.04] p-[3px]">
+            <button
+              onClick={() => setViewMode('grid')}
+              className={`rounded p-1.5 transition-colors ${
+                viewMode === 'grid'
+                  ? 'bg-white/[0.08] text-white'
+                  : 'text-white/30 hover:text-white/50'
+              }`}
+              title="Grid view"
+            >
+              <Grid3x3 className="w-3.5 h-3.5" />
+            </button>
+            <button
+              onClick={() => setViewMode('gallery')}
+              className={`rounded p-1.5 transition-colors ${
+                viewMode === 'gallery'
+                  ? 'bg-white/[0.08] text-white'
+                  : 'text-white/30 hover:text-white/50'
+              }`}
+              title="Gallery view"
+            >
+              <GalleryHorizontal className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Content area */}
+      {viewMode === 'gallery' ? (
+        <GalleryView
+          generations={dataItems}
+          onOpenDetail={setDetailGen}
+          onRetry={handleRetry}
+        />
+      ) : (
+        <div className="flex-1 overflow-y-auto p-6">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-4 content-start">
+            {itemsWithDividers.map((item) => {
+              if (item.type === 'divider') {
+                return (
+                  <div
+                    key={item.key}
+                    className="col-span-full flex items-center gap-3 py-2"
+                  >
+                    <div className="flex-1 h-px bg-white/[0.06]" />
+                    <span className="font-mono text-[9px] text-white/40 uppercase tracking-wider whitespace-nowrap">
+                      {item.label}
+                    </span>
+                    <div className="flex-1 h-px bg-white/[0.06]" />
+                  </div>
+                );
+              }
+              return (
+                <ResultCard
+                  key={item.data.id}
+                  generation={item.data}
+                  onRetry={handleRetry}
+          onDelete={handleDelete}
+                  onOpenDetail={setDetailGen}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Detail Panel */}
+      {detailGen && (
+        <DetailPanel
+          generation={detailGen}
+          allGenerations={dataItems}
+          onClose={() => setDetailGen(null)}
+          onNavigate={setDetailGen}
+          onRetry={handleRetry}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/modules/playground/playgroundModels.ts
+++ b/frontend/src/components/modules/playground/playgroundModels.ts
@@ -1,0 +1,308 @@
+import rawCatalog from '@/generated/modelCatalog.json';
+import type { PlaygroundMode } from './usePlaygroundStore';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface PlaygroundModelOption {
+  id: string;
+  displayName: string;
+  family: string;
+  description: string;
+  recommended: boolean;
+  badges: string[];
+  capabilities: string[];
+  duration:
+    | { type: 'slider'; min: number; max: number; step: number; default: number }
+    | { type: 'buttons'; options: number[]; default: number }
+    | { type: 'fixed'; value: number }
+    | null;
+  params: {
+    resolution?: { options: string[]; default: string };
+    ratio?: { options: string[]; default: string };
+    size?: { options: string[]; default: string };
+    quality?: { options: string[]; default: string };
+    seed?: boolean;
+    negativePrompt?: boolean;
+    promptExtend?: boolean;
+    watermark?: boolean;
+  };
+  maxReferenceImages: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal catalog typing
+// ---------------------------------------------------------------------------
+
+interface CatalogDuration {
+  type: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  default?: number;
+  value?: number;
+  options?: number[];
+}
+
+interface CatalogModel {
+  id: string;
+  display_name: string;
+  description: string;
+  family: string;
+  status: string;
+  capabilities: string[];
+  duration?: CatalogDuration | null;
+  params?: Record<string, unknown>;
+  inputs?: {
+    reference_images?: { max?: number };
+  };
+  ui: {
+    selection_group: string;
+    visible_in: string[];
+    recommended?: boolean;
+    order?: number;
+    badges?: string[];
+  };
+}
+
+const catalog = rawCatalog as { models: Record<string, CatalogModel> };
+const allModels = Object.entries(catalog.models);
+
+// ---------------------------------------------------------------------------
+// Family priority maps (lower number = higher priority)
+// ---------------------------------------------------------------------------
+
+const VIDEO_MODES = new Set<string>(['t2v', 'i2v', 'r2v', 'v2v']);
+
+const VIDEO_FAMILY_PRIORITY: Record<string, number> = {
+  happyhorse: 1,
+  seedance: 2,
+  kling: 3,
+  pixverse: 4,
+  wan: 5,
+  vidu: 6,
+};
+
+const IMAGE_FAMILY_PRIORITY: Record<string, number> = {
+  'gpt-image': 1,
+  wan: 2,
+  qwen: 3,
+};
+
+const FALLBACK_PRIORITY = 999;
+
+function getFamilyPriority(family: string, mode: PlaygroundMode): number {
+  const map = VIDEO_MODES.has(mode) ? VIDEO_FAMILY_PRIORITY : IMAGE_FAMILY_PRIORITY;
+  return map[family] ?? FALLBACK_PRIORITY;
+}
+
+// ---------------------------------------------------------------------------
+// Duration normalizer
+// ---------------------------------------------------------------------------
+
+function normalizeDuration(
+  raw: CatalogDuration | null | undefined,
+): PlaygroundModelOption['duration'] {
+  if (!raw) return null;
+
+  if (raw.type === 'slider') {
+    return {
+      type: 'slider',
+      min: raw.min ?? 1,
+      max: raw.max ?? 15,
+      step: raw.step ?? 1,
+      default: raw.default ?? 5,
+    };
+  }
+
+  if (raw.type === 'buttons') {
+    return {
+      type: 'buttons',
+      options: raw.options ?? [],
+      default: raw.default ?? (raw.options?.[0] ?? 5),
+    };
+  }
+
+  if (raw.type === 'fixed') {
+    return {
+      type: 'fixed',
+      value: raw.value ?? 5,
+    };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Params normalizer
+// ---------------------------------------------------------------------------
+
+function normalizeParams(
+  raw: Record<string, unknown> | undefined,
+): PlaygroundModelOption['params'] {
+  if (!raw) return {};
+
+  const result: PlaygroundModelOption['params'] = {};
+
+  // resolution
+  const res = raw.resolution;
+  if (res && typeof res === 'object' && 'options' in (res as object)) {
+    const r = res as { options?: string[]; default?: string };
+    if (r.options) {
+      result.resolution = {
+        options: r.options,
+        default: r.default ?? r.options[0] ?? '',
+      };
+    }
+  }
+
+  // ratio — catalog uses both "ratio" and "aspectRatio"
+  const ratio = raw.ratio ?? raw.aspectRatio;
+  if (ratio && typeof ratio === 'object' && 'options' in (ratio as object)) {
+    const r = ratio as { options?: string[]; default?: string };
+    if (r.options) {
+      result.ratio = {
+        options: r.options,
+        default: r.default ?? r.options[0] ?? '',
+      };
+    }
+  }
+
+  // size (image models use size instead of resolution)
+  const size = raw.size;
+  if (size && typeof size === 'object' && 'options' in (size as object)) {
+    const s = size as { options?: string[]; default?: string };
+    if (s.options) {
+      result.size = {
+        options: s.options,
+        default: s.default ?? s.options[0] ?? '',
+      };
+    }
+  }
+
+  // quality (GPT-Image-2)
+  const quality = raw.quality;
+  if (quality && typeof quality === 'object' && 'options' in (quality as object)) {
+    const q = quality as { options?: string[]; default?: string };
+    if (q.options) {
+      result.quality = {
+        options: q.options,
+        default: q.default ?? q.options[0] ?? '',
+      };
+    }
+  }
+
+  // boolean flags
+  if (typeof raw.seed === 'boolean') result.seed = raw.seed;
+  if (typeof raw.negativePrompt === 'boolean') result.negativePrompt = raw.negativePrompt;
+  if (typeof raw.promptExtend === 'boolean') result.promptExtend = raw.promptExtend;
+  if (typeof raw.watermark === 'boolean') result.watermark = raw.watermark;
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Model builder
+// ---------------------------------------------------------------------------
+
+function toOption(model: CatalogModel): PlaygroundModelOption {
+  return {
+    id: model.id,
+    displayName: model.display_name,
+    family: model.family,
+    description: model.description,
+    recommended: model.ui.recommended ?? false,
+    badges: model.ui.badges ?? [],
+    capabilities: model.capabilities,
+    duration: normalizeDuration(model.duration),
+    params: normalizeParams(model.params),
+    maxReferenceImages: model.inputs?.reference_images?.max ?? 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return all models whose capabilities include the given mode, sorted by
+ * family priority, then recommended-first, then ui.order descending (newer
+ * versions first), then alphabetically by display name.
+ *
+ * Filtering: exclude deprecated/planned models. Include hidden models that
+ * have the required capability (they are hidden from Studio but available in
+ * Playground — e.g. HappyHorse T2V, Wan 2.7 VideoEdit).
+ */
+export function getModelsForMode(mode: PlaygroundMode): PlaygroundModelOption[] {
+  return allModels
+    .filter(([, model]) => {
+      if (model.status === 'deprecated' || model.status === 'planned') return false;
+      if (!model.capabilities.includes(mode)) return false;
+      return true;
+    })
+    .sort(([, a], [, b]) => {
+      // 1. Family priority
+      const famA = getFamilyPriority(a.family, mode);
+      const famB = getFamilyPriority(b.family, mode);
+      if (famA !== famB) return famA - famB;
+
+      // 2. Recommended first
+      const recA = a.ui.recommended ? 0 : 1;
+      const recB = b.ui.recommended ? 0 : 1;
+      if (recA !== recB) return recA - recB;
+
+      // 3. ui.order descending (higher order = newer version = comes first)
+      const orderA = a.ui.order ?? 0;
+      const orderB = b.ui.order ?? 0;
+      if (orderA !== orderB) return orderB - orderA;
+
+      // 4. Alphabetical fallback
+      return a.display_name.localeCompare(b.display_name);
+    })
+    .map(([, model]) => toOption(model));
+}
+
+/**
+ * Return the default (recommended or first) model ID for a mode.
+ */
+export function getDefaultModelForMode(mode: PlaygroundMode): string {
+  const models = getModelsForMode(mode);
+  const recommended = models.find((m) => m.recommended);
+  return recommended?.id ?? models[0]?.id ?? '';
+}
+
+/**
+ * Lightweight display-info lookup — works for any model ID, regardless of
+ * mode or status.
+ */
+export function getModelDisplayInfo(
+  modelId: string,
+): { displayName: string; family: string } | null {
+  const model = catalog.models[modelId];
+  if (!model) return null;
+  return { displayName: model.display_name, family: model.family };
+}
+
+/**
+ * Return the normalized params for a model, or null if the model is unknown.
+ */
+export function getModelParams(
+  modelId: string,
+): PlaygroundModelOption['params'] | null {
+  const model = catalog.models[modelId];
+  if (!model) return null;
+  return normalizeParams(model.params);
+}
+
+/**
+ * Return the normalized duration config for a model (null when the model has
+ * no duration knob, e.g. image models).
+ */
+export function getModelDuration(
+  modelId: string,
+): PlaygroundModelOption['duration'] {
+  const model = catalog.models[modelId];
+  if (!model) return null;
+  return normalizeDuration(model.duration);
+}

--- a/frontend/src/components/modules/playground/usePlaygroundStore.ts
+++ b/frontend/src/components/modules/playground/usePlaygroundStore.ts
@@ -1,0 +1,291 @@
+import { create } from 'zustand';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PlaygroundMode = 't2i' | 'i2i' | 't2v' | 'i2v' | 'r2v' | 'v2v';
+
+export interface PlaygroundOutput {
+  id: string;
+  media_path: string;
+  media_type: 'image' | 'video';
+  thumbnail_path?: string;
+  saved_to_library: boolean;
+}
+
+export interface PlaygroundGeneration {
+  id: string;
+  mode: PlaygroundMode;
+  model_id: string;
+  prompt: string;
+  negative_prompt?: string;
+  input_media: string[];
+  parameters: Record<string, any>;
+  batch_size: number;
+  outputs: PlaygroundOutput[];
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  error?: string;
+  created_at: string;
+}
+
+export interface PlaygroundTemplate {
+  id: string;
+  name: string;
+  category: string;
+  prompt: string;
+  negative_prompt?: string;
+  default_mode?: PlaygroundMode;
+  default_model_id?: string;
+  default_parameters: Record<string, any>;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// State & Actions
+// ---------------------------------------------------------------------------
+
+interface PlaygroundState {
+  // Current input
+  mode: PlaygroundMode;
+  modelId: string;
+  prompt: string;
+  negativePrompt: string;
+  inputMedia: string[];
+  parameters: Record<string, any>;
+  batchSize: number;
+
+  // Model preferences (mode -> last used modelId)
+  modelPreferences: Partial<Record<PlaygroundMode, string>>;
+
+  // History
+  history: PlaygroundGeneration[];
+
+  // Templates
+  templates: PlaygroundTemplate[];
+
+  // UI
+  isGenerating: boolean;
+  activeGenerationIds: string[];
+  showAdvancedParams: boolean;
+  showTemplateModal: boolean;
+  showHistoryDrawer: boolean;
+
+  // Template favorites (local, not persisted to backend)
+  favoriteTemplateIds: string[];
+  toggleTemplateFavorite: (id: string) => void;
+  isTemplateFavorited: (id: string) => boolean;
+
+  // Actions — input setters
+  setMode: (mode: PlaygroundMode) => void;
+  setModelId: (modelId: string) => void;
+  setPrompt: (prompt: string) => void;
+  setNegativePrompt: (neg: string) => void;
+  setInputMedia: (media: string[]) => void;
+  setParameters: (params: Record<string, any>) => void;
+  setBatchSize: (size: number) => void;
+  setShowAdvancedParams: (show: boolean) => void;
+  setShowTemplateModal: (show: boolean) => void;
+  setShowHistoryDrawer: (show: boolean) => void;
+
+  // Actions — generation lifecycle
+  startGeneration: (gen: PlaygroundGeneration) => void;
+  updateGeneration: (gen: PlaygroundGeneration) => void;
+  removeGeneration: (id: string) => void;
+
+  // Actions — history
+  setHistory: (history: PlaygroundGeneration[]) => void;
+  appendToHistory: (gen: PlaygroundGeneration) => void;
+
+  // Actions — templates
+  setTemplates: (templates: PlaygroundTemplate[]) => void;
+  addTemplate: (template: PlaygroundTemplate) => void;
+  updateTemplate: (template: PlaygroundTemplate) => void;
+  removeTemplate: (id: string) => void;
+  applyTemplate: (template: PlaygroundTemplate) => void;
+
+  // Actions — reset
+  resetInput: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MODE: PlaygroundMode = 't2i';
+const DEFAULT_MODEL_ID = '';
+const DEFAULT_PROMPT = '';
+const DEFAULT_BATCH_SIZE = 1;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const usePlaygroundStore = create<PlaygroundState>((set, get) => ({
+  // -- Current input --------------------------------------------------------
+  mode: DEFAULT_MODE,
+  modelId: DEFAULT_MODEL_ID,
+  prompt: DEFAULT_PROMPT,
+  negativePrompt: '',
+  inputMedia: [],
+  parameters: {},
+  batchSize: DEFAULT_BATCH_SIZE,
+
+  // -- Model preferences ----------------------------------------------------
+  modelPreferences: {},
+
+  // -- History ---------------------------------------------------------------
+  history: [],
+
+  // -- Templates -------------------------------------------------------------
+  templates: [],
+
+  // -- UI --------------------------------------------------------------------
+  isGenerating: false,
+  activeGenerationIds: [],
+  showAdvancedParams: false,
+  showTemplateModal: false,
+  showHistoryDrawer: false,
+
+  // -- Template favorites ----------------------------------------------------
+  favoriteTemplateIds: [],
+  toggleTemplateFavorite: (id) => {
+    const { favoriteTemplateIds } = get();
+    if (favoriteTemplateIds.includes(id)) {
+      set({ favoriteTemplateIds: favoriteTemplateIds.filter((fid) => fid !== id) });
+    } else {
+      set({ favoriteTemplateIds: [...favoriteTemplateIds, id] });
+    }
+  },
+  isTemplateFavorited: (id) => get().favoriteTemplateIds.includes(id),
+
+  // =========================================================================
+  // Actions
+  // =========================================================================
+
+  // -- Input setters ---------------------------------------------------------
+
+  setMode: (mode) => {
+    const { modelPreferences } = get();
+    const preferredModel = modelPreferences[mode];
+    set({
+      mode,
+      ...(preferredModel !== undefined ? { modelId: preferredModel } : {}),
+    });
+  },
+
+  setModelId: (modelId) => {
+    const { mode, modelPreferences } = get();
+    set({
+      modelId,
+      modelPreferences: { ...modelPreferences, [mode]: modelId },
+    });
+  },
+
+  setPrompt: (prompt) => set({ prompt }),
+
+  setNegativePrompt: (negativePrompt) => set({ negativePrompt }),
+
+  setInputMedia: (inputMedia) => set({ inputMedia }),
+
+  setParameters: (parameters) => set({ parameters }),
+
+  setBatchSize: (batchSize) => set({ batchSize }),
+
+  setShowAdvancedParams: (showAdvancedParams) => set({ showAdvancedParams }),
+
+  setShowTemplateModal: (showTemplateModal) => set({ showTemplateModal }),
+
+  setShowHistoryDrawer: (showHistoryDrawer) => set({ showHistoryDrawer }),
+
+  // -- Generation lifecycle --------------------------------------------------
+
+  startGeneration: (gen) => {
+    const { activeGenerationIds, history } = get();
+    set({
+      activeGenerationIds: [...activeGenerationIds, gen.id],
+      history: [gen, ...history],
+      isGenerating: true,
+    });
+  },
+
+  updateGeneration: (gen) => {
+    const { history, activeGenerationIds } = get();
+    const updatedHistory = history.map((h) => (h.id === gen.id ? gen : h));
+    const isTerminal = gen.status === 'completed' || gen.status === 'failed';
+    const updatedActive = isTerminal
+      ? activeGenerationIds.filter((id) => id !== gen.id)
+      : activeGenerationIds;
+
+    set({
+      history: updatedHistory,
+      activeGenerationIds: updatedActive,
+      isGenerating: updatedActive.length > 0,
+    });
+  },
+
+  removeGeneration: (id) => {
+    const { history, activeGenerationIds } = get();
+    const updatedActive = activeGenerationIds.filter((gid) => gid !== id);
+    set({
+      history: history.filter((h) => h.id !== id),
+      activeGenerationIds: updatedActive,
+      isGenerating: updatedActive.length > 0,
+    });
+  },
+
+  // -- History ---------------------------------------------------------------
+
+  setHistory: (history) => set({ history }),
+
+  appendToHistory: (gen) => set((s) => ({ history: [gen, ...s.history] })),
+
+  // -- Templates -------------------------------------------------------------
+
+  setTemplates: (templates) => set({ templates }),
+
+  addTemplate: (template) =>
+    set((s) => ({ templates: [...s.templates, template] })),
+
+  updateTemplate: (template) =>
+    set((s) => ({
+      templates: s.templates.map((t) => (t.id === template.id ? template : t)),
+    })),
+
+  removeTemplate: (id) =>
+    set((s) => ({ templates: s.templates.filter((t) => t.id !== id) })),
+
+  applyTemplate: (template) => {
+    const patch: Partial<PlaygroundState> = {
+      prompt: template.prompt,
+    };
+    if (template.negative_prompt != null) {
+      patch.negativePrompt = template.negative_prompt;
+    }
+    if (template.default_mode != null) {
+      patch.mode = template.default_mode;
+    }
+    if (template.default_model_id != null) {
+      patch.modelId = template.default_model_id;
+    }
+    if (
+      template.default_parameters != null &&
+      Object.keys(template.default_parameters).length > 0
+    ) {
+      patch.parameters = template.default_parameters;
+    }
+    set(patch);
+  },
+
+  // -- Reset -----------------------------------------------------------------
+
+  resetInput: () =>
+    set({
+      prompt: DEFAULT_PROMPT,
+      negativePrompt: '',
+      inputMedia: [],
+      parameters: {},
+      batchSize: DEFAULT_BATCH_SIZE,
+    }),
+}));

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -397,6 +397,55 @@ export default function SettingsPage() {
                 <div className="space-y-3">
                   <h4 className="text-sm font-medium text-text-secondary">MuleRun / MuleRouter</h4>
                   <p className="text-xs text-text-secondary/60">用于 Seedance 2.0 视频生成和 GPT-Image-2 图片生成</p>
+
+                  {/* One-click login button */}
+                  {!config.MULEROUTER_API_KEY && !config.MULERUN_CLI_LOGGED_IN && (
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        try {
+                          await api.triggerMulerunLogin();
+                          const poll = setInterval(async () => {
+                            try {
+                              const env = await api.getEnvConfig();
+                              if (env.MULERUN_CLI_LOGGED_IN) {
+                                clearInterval(poll);
+                                setConfig((c) => ({ ...c, MULERUN_CLI_LOGGED_IN: true }));
+                              }
+                            } catch { /* silent */ }
+                          }, 3000);
+                          setTimeout(() => clearInterval(poll), 120000);
+                        } catch (err: any) {
+                          alert(err?.response?.data?.detail || '登录失败');
+                        }
+                      }}
+                      className="w-full py-2.5 rounded-lg bg-primary text-white text-sm font-medium hover:bg-primary/90 transition-colors"
+                    >
+                      一键登录 MuleRun
+                    </button>
+                  )}
+                  {!config.MULEROUTER_API_KEY && config.MULERUN_CLI_LOGGED_IN && (
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-2 text-sm text-green-400">
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                        MuleRun 已登录
+                      </div>
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          try {
+                            await api.triggerMulerunLogin();
+                          } catch (err: any) {
+                            alert(err?.response?.data?.detail || '登录失败');
+                          }
+                        }}
+                        className="text-xs text-text-secondary hover:text-foreground transition-colors underline underline-offset-2"
+                      >
+                        重新登录
+                      </button>
+                    </div>
+                  )}
+
                   <div>
                     <label className="block text-xs text-text-secondary mb-1">API Key</label>
                     <input
@@ -407,11 +456,10 @@ export default function SettingsPage() {
                       className="glass-input w-full"
                     />
                   </div>
-                  {/* Collapsible guide */}
                   <details className="group">
                     <summary className="text-xs text-primary cursor-pointer hover:underline flex items-center gap-1">
                       <svg className="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
-                      如何获取 MuleRun Key？
+                      手动获取 Key
                     </summary>
                     <div className="mt-2 space-y-2 pl-4 border-l border-glass-border">
                       <div className="flex items-center gap-2 text-xs text-text-secondary">

--- a/frontend/src/generated/modelCatalog.json
+++ b/frontend/src/generated/modelCatalog.json
@@ -1711,7 +1711,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Fast generation",
+      "description": "Fast generation (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V Flash",
       "docs": {
         "context_hub_doc_ids": [
@@ -1885,7 +1885,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Wan 2.6 video line",
+      "description": "Wan 2.6 video line (deprecated)",
       "display_name": "Wan 2.6 Video",
       "docs": {
         "context_hub_doc_ids": [
@@ -2165,7 +2165,29 @@
       "inputs": {},
       "params": {
         "negativePrompt": false,
-        "seed": false
+        "promptExtend": false,
+        "quality": {
+          "default": "high",
+          "options": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "seed": false,
+        "size": {
+          "default": "1024x1024",
+          "options": [
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
+            "2048x2048",
+            "2048x1152",
+            "3840x2160",
+            "2160x3840"
+          ]
+        },
+        "watermark": false
       },
       "provider": "mulerouter",
       "release_stage": "stable",
@@ -2237,6 +2259,8 @@
         }
       },
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -2318,6 +2342,8 @@
         }
       },
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -2387,6 +2413,8 @@
       "id": "happyhorse-1.0-t2v",
       "inputs": {},
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -2394,7 +2422,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": true
       },
       "provider": "aliyun",
       "release_stage": "stable",
@@ -2450,6 +2479,8 @@
       "id": "happyhorse-1.0-video-edit",
       "inputs": {},
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -2457,7 +2488,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": true
       },
       "provider": "aliyun",
       "release_stage": "stable",
@@ -2537,7 +2569,6 @@
             "1:1"
           ]
         },
-        "audio": true,
         "cfgScale": {
           "default": 0.5,
           "max": 1,
@@ -2552,8 +2583,10 @@
           ]
         },
         "negativePrompt": true,
+        "promptExtend": false,
+        "seed": false,
         "sound": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "kling",
       "release_stage": "stable",
@@ -2654,7 +2687,9 @@
           ]
         },
         "negativePrompt": true,
-        "watermark": true
+        "promptExtend": false,
+        "seed": false,
+        "watermark": false
       },
       "provider": "kling",
       "release_stage": "stable",
@@ -2732,6 +2767,8 @@
       },
       "params": {
         "audio": true,
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -2815,6 +2852,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -2822,7 +2861,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": false
       },
       "provider": "pixverse",
       "release_stage": "stable",
@@ -2950,6 +2990,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -2957,7 +2999,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": false
       },
       "provider": "pixverse",
       "release_stage": "stable",
@@ -3031,6 +3074,8 @@
       },
       "params": {
         "audio": true,
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3116,6 +3161,17 @@
         "negativePrompt": true,
         "promptExtend": true,
         "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280"
+          ]
+        },
         "watermark": true
       },
       "provider": "aliyun",
@@ -3180,6 +3236,17 @@
         "negativePrompt": true,
         "promptExtend": true,
         "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280"
+          ]
+        },
         "watermark": true
       },
       "provider": "aliyun",
@@ -3253,6 +3320,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -3336,6 +3405,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -3414,6 +3485,8 @@
       "id": "seedance-2.0-t2v",
       "inputs": {},
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -3510,6 +3583,8 @@
             "large"
           ]
         },
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3603,6 +3678,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3612,7 +3689,7 @@
           ]
         },
         "seed": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "vidu",
       "release_stage": "stable",
@@ -3702,6 +3779,8 @@
             "large"
           ]
         },
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3793,6 +3872,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -3802,7 +3883,7 @@
           ]
         },
         "seed": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "vidu",
       "release_stage": "stable",
@@ -4304,7 +4385,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Legacy model, supports R2V",
+      "description": "Legacy model, supports R2V (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V / R2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -4367,12 +4448,7 @@
         "order": 75,
         "recommended": false,
         "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
+        "visible_in": []
       }
     },
     "wan2.6-i2v-flash": {
@@ -4386,7 +4462,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Fast generation",
+      "description": "Fast generation (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V Flash",
       "docs": {
         "context_hub_doc_ids": [
@@ -4449,12 +4525,7 @@
         "order": 70,
         "recommended": false,
         "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
+        "visible_in": []
       }
     },
     "wan2.6-image": {
@@ -4529,7 +4600,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Dedicated reference-to-video route",
+      "description": "Dedicated reference-to-video route (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 R2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -4557,7 +4628,7 @@
         "wan2.6-",
         "wan2.7-"
       ],
-      "status": "hidden",
+      "status": "deprecated",
       "supported_backends": [
         "dashscope"
       ],
@@ -4764,7 +4835,25 @@
           "max": 9
         }
       },
-      "params": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280",
+            "1024*576",
+            "576*1024"
+          ]
+        },
+        "watermark": true
+      },
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
@@ -4830,7 +4919,25 @@
           "max": 9
         }
       },
-      "params": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280",
+            "1024*576",
+            "576*1024"
+          ]
+        },
+        "watermark": true
+      },
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
@@ -4905,6 +5012,8 @@
         }
       },
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5098,7 +5207,29 @@
       "model_line_id": "gpt-image/gpt-image-2",
       "params": {
         "negativePrompt": false,
-        "seed": false
+        "promptExtend": false,
+        "quality": {
+          "default": "high",
+          "options": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "seed": false,
+        "size": {
+          "default": "1024x1024",
+          "options": [
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
+            "2048x2048",
+            "2048x1152",
+            "3840x2160",
+            "2160x3840"
+          ]
+        },
+        "watermark": false
       },
       "provider": "mulerouter",
       "release_stage": "stable",
@@ -5168,6 +5299,8 @@
       "mode": "i2v",
       "model_line_id": "happyhorse/happyhorse-1.0-t2v",
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5175,7 +5308,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": true
       },
       "provider": "aliyun",
       "release_stage": "stable",
@@ -5245,6 +5379,8 @@
       "mode": "i2v",
       "model_line_id": "happyhorse/happyhorse-1.0-video",
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5334,6 +5470,8 @@
       "mode": "r2v",
       "model_line_id": "happyhorse/happyhorse-1.0-video",
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5411,6 +5549,8 @@
       "mode": "i2v",
       "model_line_id": "happyhorse/happyhorse-1.0-video-edit",
       "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -5418,7 +5558,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": true
       },
       "provider": "aliyun",
       "release_stage": "stable",
@@ -5502,7 +5643,6 @@
             "1:1"
           ]
         },
-        "audio": true,
         "cfgScale": {
           "default": 0.5,
           "max": 1,
@@ -5517,8 +5657,10 @@
           ]
         },
         "negativePrompt": true,
+        "promptExtend": false,
+        "seed": false,
         "sound": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "kling",
       "release_stage": "stable",
@@ -5631,7 +5773,9 @@
           ]
         },
         "negativePrompt": true,
-        "watermark": true
+        "promptExtend": false,
+        "seed": false,
+        "watermark": false
       },
       "provider": "kling",
       "release_stage": "stable",
@@ -5721,6 +5865,8 @@
       "model_line_id": "pixverse/pixverse-c1-video",
       "params": {
         "audio": true,
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -5813,6 +5959,8 @@
       "mode": "r2v",
       "model_line_id": "pixverse/pixverse-c1-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -5820,7 +5968,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": false
       },
       "provider": "pixverse",
       "release_stage": "stable",
@@ -5961,6 +6110,8 @@
       "mode": "r2v",
       "model_line_id": "pixverse/pixverse-v5.6-r2v",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -5968,7 +6119,8 @@
             "1080p"
           ]
         },
-        "seed": true
+        "seed": true,
+        "watermark": false
       },
       "provider": "pixverse",
       "release_stage": "stable",
@@ -6051,6 +6203,8 @@
       "model_line_id": "pixverse/pixverse/pixverse-v6-video",
       "params": {
         "audio": true,
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6145,6 +6299,17 @@
         "negativePrompt": true,
         "promptExtend": true,
         "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280"
+          ]
+        },
         "watermark": true
       },
       "provider": "aliyun",
@@ -6218,6 +6383,17 @@
         "negativePrompt": true,
         "promptExtend": true,
         "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280"
+          ]
+        },
         "watermark": true
       },
       "provider": "aliyun",
@@ -6300,6 +6476,8 @@
       "mode": "i2v",
       "model_line_id": "seedance/seedance-2.0-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -6391,6 +6569,8 @@
       "mode": "r2v",
       "model_line_id": "seedance/seedance-2.0-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -6477,6 +6657,8 @@
       "mode": "t2v",
       "model_line_id": "seedance/seedance-2.0-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [
@@ -6581,6 +6763,8 @@
             "large"
           ]
         },
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6686,6 +6870,8 @@
       "mode": "r2v",
       "model_line_id": "vidu/viduq3-pro-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6695,7 +6881,7 @@
           ]
         },
         "seed": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "vidu",
       "release_stage": "stable",
@@ -6797,6 +6983,8 @@
             "large"
           ]
         },
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6900,6 +7088,8 @@
       "mode": "r2v",
       "model_line_id": "vidu/viduq3-turbo-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "720p",
           "options": [
@@ -6909,7 +7099,7 @@
           ]
         },
         "seed": true,
-        "watermark": true
+        "watermark": false
       },
       "provider": "vidu",
       "release_stage": "stable",
@@ -7447,7 +7637,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Fast generation",
+      "description": "Fast generation (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V Flash",
       "docs": {
         "context_hub_doc_ids": [
@@ -7514,12 +7704,7 @@
         "order": 70,
         "recommended": false,
         "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
+        "visible_in": []
       }
     },
     "wan/wan2.6-image#i2i": {
@@ -7660,7 +7845,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Legacy model, supports R2V",
+      "description": "Legacy model, supports R2V (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 I2V / R2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -7731,12 +7916,7 @@
         "order": 75,
         "recommended": false,
         "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
+        "visible_in": []
       }
     },
     "wan/wan2.6-video#r2v": {
@@ -7750,7 +7930,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Dedicated reference-to-video route",
+      "description": "Dedicated reference-to-video route (deprecated — replaced by 2.7)",
       "display_name": "Wan 2.6 R2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -7786,7 +7966,7 @@
           "gateway": "dashscope"
         }
       },
-      "status": "hidden",
+      "status": "deprecated",
       "supported_backends": [
         "dashscope"
       ],
@@ -7842,7 +8022,25 @@
       "legacy_model_id": "wan2.7-image",
       "mode": "image",
       "model_line_id": "wan/wan2.7-image",
-      "params": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280",
+            "1024*576",
+            "576*1024"
+          ]
+        },
+        "watermark": true
+      },
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
@@ -7917,7 +8115,25 @@
       "legacy_model_id": "wan2.7-image-pro",
       "mode": "image",
       "model_line_id": "wan/wan2.7-image-pro",
-      "params": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "seed": true,
+        "size": {
+          "default": "1280*1280",
+          "options": [
+            "1024*1024",
+            "1280*1280",
+            "1440*1440",
+            "2048*2048",
+            "1280*720",
+            "720*1280",
+            "1024*576",
+            "576*1024"
+          ]
+        },
+        "watermark": true
+      },
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
@@ -8106,6 +8322,8 @@
       "mode": "r2v",
       "model_line_id": "wan/wan2.7-video",
       "params": {
+        "negativePrompt": false,
+        "promptExtend": false,
         "resolution": {
           "default": "1080p",
           "options": [

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1124,6 +1124,11 @@ export const api = {
         return res.data;
     },
 
+    triggerMulerunLogin: async () => {
+        const res = await axios.post(`${API_URL}/config/mulerun-login`);
+        return res.data;
+    },
+
     extractLastFrame: async (scriptId: string, frameId: string, videoTaskId: string) => {
         const res = await axios.post(`${API_URL}/projects/${scriptId}/frames/${frameId}/extract_last_frame`, {
             video_task_id: videoTaskId,
@@ -1462,4 +1467,91 @@ export const crudApi = {
         });
         return res.data;
     }
+};
+
+// ─── Playground API ─────────────────────────────────────────────────────────
+
+export interface PlaygroundGenerateRequest {
+  mode: string;
+  model_id: string;
+  prompt: string;
+  negative_prompt?: string;
+  input_media?: string[];
+  parameters?: Record<string, any>;
+  batch_size?: number;
+}
+
+export interface PlaygroundGenerationResponse {
+  id: string;
+  mode: string;
+  model_id: string;
+  prompt: string;
+  negative_prompt?: string;
+  input_media: string[];
+  parameters: Record<string, any>;
+  batch_size: number;
+  outputs: Array<{
+    id: string;
+    media_path: string;
+    media_type: string;
+    thumbnail_path?: string;
+    saved_to_library: boolean;
+  }>;
+  status: string;
+  error?: string;
+  created_at: string;
+}
+
+export interface PlaygroundTemplateResponse {
+  id: string;
+  name: string;
+  category: string;
+  prompt: string;
+  negative_prompt?: string;
+  default_mode?: string;
+  default_model_id?: string;
+  default_parameters: Record<string, any>;
+  created_at: string;
+  updated_at: string;
+}
+
+export const playgroundApi = {
+  generate: (data: PlaygroundGenerateRequest) =>
+    axios.post<PlaygroundGenerationResponse>(API_URL + "/playground/generate", data).then(r => r.data),
+
+  getHistory: (limit = 50, offset = 0) =>
+    axios.get<PlaygroundGenerationResponse[]>(API_URL + "/playground/history", { params: { limit, offset } }).then(r => r.data),
+
+  getGeneration: (id: string) =>
+    axios.get<PlaygroundGenerationResponse>(API_URL + "/playground/history/" + id).then(r => r.data),
+
+  getGenerationStatus: (id: string) =>
+    axios.get<{ id: string; status: string; outputs: any[]; error?: string }>(API_URL + "/playground/history/" + id + "/status").then(r => r.data),
+
+  deleteGeneration: (id: string) =>
+    axios.delete(API_URL + "/playground/history/" + id).then(r => r.data),
+
+  saveToLibrary: (generationId: string, outputId: string, category?: string) =>
+    axios.post(API_URL + "/playground/history/" + generationId + "/outputs/" + outputId + "/save-to-library", { category: category || "general" }).then(r => r.data),
+
+  getTemplates: () =>
+    axios.get<PlaygroundTemplateResponse[]>(API_URL + "/playground/templates").then(r => r.data),
+
+  createTemplate: (data: { name: string; category?: string; prompt: string; negative_prompt?: string; default_mode?: string; default_model_id?: string; default_parameters?: Record<string, any> }) =>
+    axios.post<PlaygroundTemplateResponse>(API_URL + "/playground/templates", data).then(r => r.data),
+
+  updateTemplate: (id: string, data: Partial<{ name: string; category: string; prompt: string; negative_prompt: string; default_mode: string; default_model_id: string; default_parameters: Record<string, any> }>) =>
+    axios.put<PlaygroundTemplateResponse>(API_URL + "/playground/templates/" + id, data).then(r => r.data),
+
+  deleteTemplate: (id: string) =>
+    axios.delete(API_URL + "/playground/templates/" + id).then(r => r.data),
+
+  // Upload media file for playground input (returns file path)
+  uploadMedia: (file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    return axios.post<{ path: string }>(API_URL + "/playground/upload", formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    }).then(r => r.data);
+  },
 };

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -86,6 +86,15 @@ const config: Config = {
         "base": "250ms",
         "slow": "400ms",
       },
+      keyframes: {
+        shimmer: {
+          "0%": { backgroundPosition: "200% 0" },
+          "100%": { backgroundPosition: "-200% 0" },
+        },
+      },
+      animation: {
+        shimmer: "shimmer 2s infinite linear",
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":

--- a/src/apps/comic_gen/api.py
+++ b/src/apps/comic_gen/api.py
@@ -64,6 +64,10 @@ env_path = os.path.join(_project_root, ".env")
 if os.path.exists(env_path):
     load_dotenv(env_path, override=True)
 
+# Mount playground router AFTER .env is loaded (adapters read API keys from env)
+from ..playground.api import router as playground_router
+app.include_router(playground_router, prefix="/playground")
+
 # Debug: Print OSS configuration at startup
 logger.info(f"STARTUP: OSS_ENDPOINT={os.getenv('OSS_ENDPOINT')}, OSS_BUCKET_NAME={os.getenv('OSS_BUCKET_NAME')}, OSS_BASE_PATH={os.getenv('OSS_BASE_PATH')}")
 
@@ -100,6 +104,11 @@ app.mount("/files/outputs", StaticFiles(directory="output"), name="files_outputs
 app.mount("/files/videos", StaticFiles(directory="output/video"), name="files_videos")
 app.mount("/files/assets", StaticFiles(directory="output/assets"), name="files_assets")
 app.mount("/files", StaticFiles(directory="output"), name="files")
+
+# Ensure playground output directories exist
+os.makedirs("output/playground/images", exist_ok=True)
+os.makedirs("output/playground/videos", exist_ok=True)
+app.mount("/files/playground", StaticFiles(directory="output/playground"), name="files_playground")
 
 
 # Initialize pipeline
@@ -3528,6 +3537,23 @@ def _check_mulerun_cli_status() -> bool:
         return result.returncode == 0
     except Exception:
         return False
+
+
+@app.post("/config/mulerun-login")
+def trigger_mulerun_login():
+    """Trigger mulerun login — opens browser for OAuth."""
+    import shutil, subprocess
+    if shutil.which("mulerun") is None:
+        raise HTTPException(status_code=400, detail="MuleRun CLI 未安装。请先运行: npm i -g @mulerunai/cli")
+    try:
+        subprocess.Popen(
+            ["mulerun", "login"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return {"status": "ok", "message": "浏览器已打开，请完成登录"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"启动登录失败: {e}")
 
 
 @app.get("/config/env")

--- a/src/apps/playground/api.py
+++ b/src/apps/playground/api.py
@@ -1,0 +1,180 @@
+"""Playground API routes — generation, history, and template management."""
+
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, UploadFile, File
+
+from .models import (
+    CreateTemplateRequest,
+    GenerateRequest,
+    PlaygroundTemplate,
+    SaveToLibraryRequest,
+    UpdateTemplateRequest,
+)
+from .service import PlaygroundService
+from .storage import PlaygroundStorage
+from ...utils import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["playground"])
+
+# Module-level singletons — initialised when the router is first imported.
+_storage = PlaygroundStorage()
+_service = PlaygroundService(_storage)
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+def generate(request: GenerateRequest, background_tasks: BackgroundTasks):
+    """Create a generation record and kick off processing in the background."""
+    gen = _service.create_generation(request)
+    background_tasks.add_task(_service.process_generation, gen.id)
+    return gen
+
+
+router.add_api_route("/generate", generate, methods=["POST"])
+
+# ---------------------------------------------------------------------------
+# History
+# ---------------------------------------------------------------------------
+
+
+def list_history(limit: int = 50, offset: int = 0):
+    """Return paginated generation history, newest first."""
+    return _storage.list_history(limit=limit, offset=offset)
+
+
+def get_generation(generation_id: str):
+    """Return full details for a single generation."""
+    gen = _storage.get_generation(generation_id)
+    if not gen:
+        raise HTTPException(status_code=404, detail="Generation not found")
+    return gen
+
+
+def get_generation_status(generation_id: str):
+    """Return lightweight status payload for polling."""
+    gen = _storage.get_generation(generation_id)
+    if not gen:
+        raise HTTPException(status_code=404, detail="Generation not found")
+    return {
+        "id": gen.id,
+        "status": gen.status,
+        "outputs": gen.outputs,
+        "error": gen.error,
+    }
+
+
+def delete_generation(generation_id: str):
+    """Delete a generation record and its outputs."""
+    if not _storage.delete_generation(generation_id):
+        raise HTTPException(status_code=404, detail="Generation not found")
+    return {"ok": True}
+
+
+def save_to_library(
+    generation_id: str,
+    output_id: str,
+    request: Optional[SaveToLibraryRequest] = None,
+):
+    """Save a specific generation output to the project library."""
+    category = request.category if request else "general"
+    if not _service.save_to_library(generation_id, output_id, category):
+        raise HTTPException(status_code=404, detail="Generation or output not found")
+    return {"ok": True}
+
+
+router.add_api_route("/history", list_history, methods=["GET"])
+router.add_api_route("/history/{generation_id}", get_generation, methods=["GET"])
+router.add_api_route(
+    "/history/{generation_id}/status", get_generation_status, methods=["GET"]
+)
+router.add_api_route(
+    "/history/{generation_id}", delete_generation, methods=["DELETE"]
+)
+router.add_api_route(
+    "/history/{generation_id}/outputs/{output_id}/save-to-library",
+    save_to_library,
+    methods=["POST"],
+)
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+
+def list_templates():
+    """Return all saved prompt templates."""
+    return _storage.list_templates()
+
+
+def create_template(request: CreateTemplateRequest):
+    """Create a new prompt template."""
+    now = datetime.now(timezone.utc).isoformat()
+    template = PlaygroundTemplate(
+        id=str(uuid.uuid4()),
+        name=request.name,
+        category=request.category or "general",
+        prompt=request.prompt,
+        negative_prompt=request.negative_prompt,
+        default_mode=request.default_mode,
+        default_model_id=request.default_model_id,
+        default_parameters=request.default_parameters or {},
+        created_at=now,
+        updated_at=now,
+    )
+    _storage.add_template(template)
+    return template
+
+
+def update_template(template_id: str, request: UpdateTemplateRequest):
+    """Update an existing prompt template (partial update)."""
+    template = _storage.get_template(template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+    update_data = request.model_dump(exclude_none=True)
+    for key, value in update_data.items():
+        setattr(template, key, value)
+    template.updated_at = datetime.now(timezone.utc).isoformat()
+    _storage.update_template(template)
+    return template
+
+
+def delete_template(template_id: str):
+    """Delete a prompt template."""
+    if not _storage.delete_template(template_id):
+        raise HTTPException(status_code=404, detail="Template not found")
+    return {"ok": True}
+
+
+router.add_api_route("/templates", list_templates, methods=["GET"])
+router.add_api_route("/templates", create_template, methods=["POST"])
+router.add_api_route("/templates/{template_id}", update_template, methods=["PUT"])
+router.add_api_route("/templates/{template_id}", delete_template, methods=["DELETE"])
+
+# ---------------------------------------------------------------------------
+# Upload
+# ---------------------------------------------------------------------------
+
+UPLOAD_DIR = os.path.join("output", "playground", "uploads")
+
+
+async def upload_media(file: UploadFile = File(...)):
+    """Upload a media file for use as playground input (reference image, first frame, etc.)."""
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    ext = os.path.splitext(file.filename or "file")[1] or ".bin"
+    filename = f"{uuid.uuid4()}{ext}"
+    dest = os.path.join(UPLOAD_DIR, filename)
+    contents = await file.read()
+    with open(dest, "wb") as f:
+        f.write(contents)
+    return {"path": dest}
+
+
+router.add_api_route("/upload", upload_media, methods=["POST"])

--- a/src/apps/playground/models.py
+++ b/src/apps/playground/models.py
@@ -1,0 +1,82 @@
+from typing import List, Optional
+from enum import Enum
+from pydantic import BaseModel, Field
+
+
+class PlaygroundMode(str, Enum):
+    T2I = "t2i"
+    I2I = "i2i"
+    T2V = "t2v"
+    I2V = "i2v"
+    R2V = "r2v"
+    V2V = "v2v"
+
+
+class PlaygroundOutput(BaseModel):
+    id: str = Field(..., description="Unique identifier (UUID)")
+    media_path: str = Field(..., description="Generated file path relative to output/")
+    media_type: str = Field(..., description="Output media type: image or video")
+    thumbnail_path: Optional[str] = Field(None, description="Thumbnail file path relative to output/")
+    saved_to_library: bool = Field(False, description="Whether this output has been saved to the project library")
+
+
+class PlaygroundGeneration(BaseModel):
+    id: str = Field(..., description="Unique identifier (UUID)")
+    mode: PlaygroundMode = Field(..., description="Generation mode")
+    model_id: str = Field(..., description="Model identifier from model catalog")
+    prompt: str = Field(..., description="Text prompt for generation")
+    negative_prompt: Optional[str] = Field(None, description="Negative prompt to exclude undesired elements")
+    input_media: List[str] = Field(default_factory=list, description="Input file paths for image/video-conditioned modes")
+    parameters: dict = Field(default_factory=dict, description="Generation parameters (resolution, duration, aspect_ratio, etc.)")
+    batch_size: int = Field(1, ge=1, le=4, description="Number of outputs to generate per request (1-4)")
+    outputs: List[PlaygroundOutput] = Field(default_factory=list, description="Generated outputs")
+    status: str = Field("pending", description="Generation status: pending/processing/completed/failed")
+    error: Optional[str] = Field(None, description="Error message if generation failed")
+    created_at: str = Field(..., description="Creation timestamp in ISO 8601 format")
+
+
+class PlaygroundTemplate(BaseModel):
+    id: str = Field(..., description="Unique identifier (UUID)")
+    name: str = Field(..., description="Template display name")
+    category: str = Field("general", description="Template category: image/video/general")
+    prompt: str = Field(..., description="Template prompt text")
+    negative_prompt: Optional[str] = Field(None, description="Default negative prompt")
+    default_mode: Optional[PlaygroundMode] = Field(None, description="Default generation mode for this template")
+    default_model_id: Optional[str] = Field(None, description="Default model identifier")
+    default_parameters: dict = Field(default_factory=dict, description="Default generation parameters")
+    created_at: str = Field(..., description="Creation timestamp in ISO 8601 format")
+    updated_at: str = Field(..., description="Last update timestamp in ISO 8601 format")
+
+
+class GenerateRequest(BaseModel):
+    mode: PlaygroundMode = Field(..., description="Generation mode")
+    model_id: str = Field(..., description="Model identifier from model catalog")
+    prompt: str = Field(..., description="Text prompt for generation")
+    negative_prompt: Optional[str] = Field(None, description="Negative prompt to exclude undesired elements")
+    input_media: Optional[List[str]] = Field(None, description="Input file paths for image/video-conditioned modes")
+    parameters: Optional[dict] = Field(None, description="Generation parameters (resolution, duration, aspect_ratio, etc.)")
+    batch_size: Optional[int] = Field(1, ge=1, le=4, description="Number of outputs to generate (1-4)")
+
+
+class SaveToLibraryRequest(BaseModel):
+    category: str = Field("general", description="Library category for the saved output")
+
+
+class CreateTemplateRequest(BaseModel):
+    name: str = Field(..., description="Template display name")
+    category: Optional[str] = Field("general", description="Template category: image/video/general")
+    prompt: str = Field(..., description="Template prompt text")
+    negative_prompt: Optional[str] = Field(None, description="Default negative prompt")
+    default_mode: Optional[PlaygroundMode] = Field(None, description="Default generation mode")
+    default_model_id: Optional[str] = Field(None, description="Default model identifier")
+    default_parameters: Optional[dict] = Field(None, description="Default generation parameters")
+
+
+class UpdateTemplateRequest(BaseModel):
+    name: Optional[str] = Field(None, description="Template display name")
+    category: Optional[str] = Field(None, description="Template category: image/video/general")
+    prompt: Optional[str] = Field(None, description="Template prompt text")
+    negative_prompt: Optional[str] = Field(None, description="Default negative prompt")
+    default_mode: Optional[PlaygroundMode] = Field(None, description="Default generation mode")
+    default_model_id: Optional[str] = Field(None, description="Default model identifier")
+    default_parameters: Optional[dict] = Field(None, description="Default generation parameters")

--- a/src/apps/playground/service.py
+++ b/src/apps/playground/service.py
@@ -1,0 +1,411 @@
+"""Playground service layer -- orchestrates AI generation by delegating to existing model adapters.
+
+Routes based on model_id to the appropriate adapter (WanxModel, KlingModel,
+ViduModel, MuleRouterVideoModel/ImageModel, WanxImageModel).  Mirrors the
+routing logic in ``src/apps/comic_gen/pipeline.py:process_video_task()``.
+"""
+
+import os
+import shutil
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from .models import (
+    GenerateRequest,
+    PlaygroundGeneration,
+    PlaygroundMode,
+    PlaygroundOutput,
+)
+from .storage import PlaygroundStorage
+from ...utils import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Output directories
+# ---------------------------------------------------------------------------
+IMAGE_OUTPUT_DIR = os.path.join("output", "playground", "images")
+VIDEO_OUTPUT_DIR = os.path.join("output", "playground", "videos")
+
+
+class PlaygroundService:
+    """High-level service that creates generation records and delegates to
+    the correct model adapter for execution."""
+
+    def __init__(self, storage: PlaygroundStorage):
+        self.storage = storage
+        # Lazy-initialised model instances (cached for the lifetime of the service)
+        self._wanx_model = None
+        self._wanx_image_model = None
+        self._kling_model = None
+        self._vidu_model = None
+        self._mulerouter_video_model = None
+        self._mulerouter_image_model = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def create_generation(self, request: GenerateRequest) -> PlaygroundGeneration:
+        """Create a :class:`PlaygroundGeneration` record with *status=pending*,
+        persist it via storage, and return it."""
+        gen = PlaygroundGeneration(
+            id=str(uuid.uuid4()),
+            mode=request.mode,
+            model_id=request.model_id,
+            prompt=request.prompt,
+            negative_prompt=request.negative_prompt,
+            input_media=request.input_media or [],
+            parameters=request.parameters or {},
+            batch_size=request.batch_size or 1,
+            outputs=[],
+            status="pending",
+            error=None,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        self.storage.add_generation(gen)
+        return gen
+
+    def process_generation(self, generation_id: str) -> None:
+        """Execute the actual generation.  Intended to run in a background
+        thread -- all calls are synchronous (blocking)."""
+        gen = self.storage.get_generation(generation_id)
+        if gen is None:
+            logger.error("Generation %s not found", generation_id)
+            return
+
+        # Mark processing
+        gen.status = "processing"
+        self.storage.update_generation(gen)
+
+        try:
+            mode = gen.mode
+            if mode in (PlaygroundMode.T2I, PlaygroundMode.I2I):
+                self._process_image_generation(gen)
+            elif mode in (PlaygroundMode.T2V, PlaygroundMode.I2V, PlaygroundMode.R2V, PlaygroundMode.V2V):
+                self._process_video_generation(gen)
+            else:
+                raise ValueError(f"Unsupported playground mode: {mode}")
+
+            gen.status = "completed"
+        except Exception as exc:
+            logger.exception("Generation %s failed", generation_id)
+            gen.status = "failed"
+            gen.error = str(exc)
+
+        self.storage.update_generation(gen)
+
+    def save_to_library(self, generation_id: str, output_id: str, category: str = "general") -> bool:
+        """Copy a generated output to ``output/assets/{category}/`` and flag
+        :pyattr:`PlaygroundOutput.saved_to_library` = True."""
+        gen = self.storage.get_generation(generation_id)
+        if gen is None:
+            logger.warning("save_to_library: generation %s not found", generation_id)
+            return False
+
+        target_output: Optional[PlaygroundOutput] = None
+        for out in gen.outputs:
+            if out.id == output_id:
+                target_output = out
+                break
+        if target_output is None:
+            logger.warning("save_to_library: output %s not found in generation %s", output_id, generation_id)
+            return False
+
+        # media_path is stored as e.g. "output/playground/images/t2i_xxx_0.png"
+        # Normalise: try as-is first, then strip leading "output/" and re-join
+        src_path = target_output.media_path
+        if not os.path.isfile(src_path):
+            alt = os.path.join("output", target_output.media_path)
+            if os.path.isfile(alt):
+                src_path = alt
+        if not os.path.isfile(src_path):
+            logger.error("save_to_library: source file not found: %s", target_output.media_path)
+            return False
+
+        dest_dir = os.path.join("output", "assets", category)
+        os.makedirs(dest_dir, exist_ok=True)
+
+        dest_path = os.path.join(dest_dir, os.path.basename(src_path))
+        shutil.copy2(src_path, dest_path)
+        logger.info("Saved output %s to library: %s", output_id, dest_path)
+
+        target_output.saved_to_library = True
+        self.storage.update_generation(gen)
+        return True
+
+    # ------------------------------------------------------------------
+    # Image generation (t2i / i2i)
+    # ------------------------------------------------------------------
+
+    def _process_image_generation(self, gen: PlaygroundGeneration) -> None:
+        os.makedirs(IMAGE_OUTPUT_DIR, exist_ok=True)
+
+        model_lower = gen.model_id.lower()
+        failures = []
+
+        for idx in range(gen.batch_size):
+            ext = "png"
+            out_filename = f"{gen.mode.value}_{gen.id}_{idx}.{ext}"
+            out_path = os.path.join(IMAGE_OUTPUT_DIR, out_filename)
+
+            try:
+                if model_lower.startswith("gpt-image"):
+                    self._generate_image_mulerouter(gen, out_path, idx)
+                else:
+                    self._generate_image_wanx(gen, out_path, idx)
+
+                output_entry = PlaygroundOutput(
+                    id=str(uuid.uuid4()),
+                    media_path=out_path,
+                    media_type="image",
+                )
+                gen.outputs.append(output_entry)
+                self.storage.update_generation(gen)
+            except Exception as exc:
+                logger.error("Image generation %s batch %d failed: %s", gen.id, idx, exc)
+                failures.append(str(exc))
+
+        if failures and not gen.outputs:
+            raise RuntimeError(f"All {len(failures)} batch items failed: {failures[0]}")
+
+    def _generate_image_wanx(self, gen: PlaygroundGeneration, out_path: str, _idx: int) -> None:
+        """Delegate to :class:`WanxImageModel` (DashScope image generation)."""
+        from ...models.image import WanxImageModel
+
+        if self._wanx_image_model is None:
+            self._wanx_image_model = WanxImageModel({})
+
+        params = gen.parameters
+        kwargs = {
+            "model_name": gen.model_id,
+            "size": params.get("size", "1280*1280"),
+            "n": 1,
+            "negative_prompt": gen.negative_prompt,
+            "seed": params.get("seed"),
+            "prompt_extend": params.get("prompt_extend", True),
+            "watermark": params.get("watermark", False),
+        }
+
+        # i2i: attach reference images from input_media
+        ref_paths = list(gen.input_media) if gen.mode == PlaygroundMode.I2I else []
+        if ref_paths:
+            kwargs["ref_image_paths"] = ref_paths
+
+        self._wanx_image_model.generate(
+            prompt=gen.prompt,
+            output_path=out_path,
+            **kwargs,
+        )
+
+    def _generate_image_mulerouter(self, gen: PlaygroundGeneration, out_path: str, _idx: int) -> None:
+        """Delegate to :class:`MuleRouterImageModel` (GPT-Image-2)."""
+        from ...models.mulerouter import MuleRouterImageModel
+
+        if self._mulerouter_image_model is None:
+            self._mulerouter_image_model = MuleRouterImageModel({})
+
+        params = gen.parameters
+        kwargs = {
+            "size": params.get("size", "1024x1024"),
+            "quality": params.get("quality", "high"),
+            "n": 1,
+        }
+
+        # i2i: attach reference images
+        if gen.mode == PlaygroundMode.I2I and gen.input_media:
+            kwargs["ref_image_paths"] = list(gen.input_media)
+
+        self._mulerouter_image_model.generate(
+            prompt=gen.prompt,
+            output_path=out_path,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Video generation (t2v / i2v / r2v / v2v)
+    # ------------------------------------------------------------------
+
+    def _process_video_generation(self, gen: PlaygroundGeneration) -> None:
+        os.makedirs(VIDEO_OUTPUT_DIR, exist_ok=True)
+
+        model_lower = gen.model_id.lower()
+        failures = []
+
+        for idx in range(gen.batch_size):
+            out_filename = f"{gen.mode.value}_{gen.id}_{idx}.mp4"
+            out_path = os.path.join(VIDEO_OUTPUT_DIR, out_filename)
+
+            try:
+                if model_lower.startswith("seedance"):
+                    self._generate_video_mulerouter(gen, out_path)
+                elif model_lower.startswith("kling"):
+                    self._generate_video_kling(gen, out_path)
+                elif model_lower.startswith("vidu") or model_lower.startswith("viduq"):
+                    self._generate_video_vidu(gen, out_path)
+                elif model_lower.startswith("happyhorse"):
+                    self._generate_video_wanx(gen, out_path)
+                elif model_lower.startswith("pixverse"):
+                    self._generate_video_wanx(gen, out_path)
+                else:
+                    self._generate_video_wanx(gen, out_path)
+
+                output_entry = PlaygroundOutput(
+                    id=str(uuid.uuid4()),
+                    media_path=out_path,
+                    media_type="video",
+                )
+                gen.outputs.append(output_entry)
+                self.storage.update_generation(gen)
+            except Exception as exc:
+                logger.error("Video generation %s batch %d failed: %s", gen.id, idx, exc)
+                failures.append(str(exc))
+
+        if failures and not gen.outputs:
+            raise RuntimeError(f"All {len(failures)} batch items failed: {failures[0]}")
+
+    # -- adapter delegates ------------------------------------------------
+
+    def _generate_video_wanx(self, gen: PlaygroundGeneration, out_path: str) -> None:
+        """Delegate to :class:`WanxModel` (DashScope video generation -- wan2.x / happyhorse)."""
+        from ...models.wanx import WanxModel
+
+        if self._wanx_model is None:
+            self._wanx_model = WanxModel({})
+
+        params = gen.parameters
+        img_path, img_url = self._resolve_first_input_media(gen)
+
+        kwargs = {
+            "model": gen.model_id,
+            "duration": params.get("duration", 5),
+            "resolution": params.get("resolution", "720P"),
+            "seed": params.get("seed"),
+            "negative_prompt": gen.negative_prompt,
+            "prompt_extend": params.get("prompt_extend", True),
+            "watermark": params.get("watermark", False),
+            "ratio": params.get("ratio"),
+            "audio_url": params.get("audio_url"),
+        }
+
+        # r2v: reference images
+        if gen.mode == PlaygroundMode.R2V and gen.input_media:
+            kwargs["ref_image_urls"] = list(gen.input_media)
+
+        # v2v: video input
+        if gen.mode == PlaygroundMode.V2V and gen.input_media:
+            kwargs["video_url"] = gen.input_media[0]
+
+        self._wanx_model.generate(
+            prompt=gen.prompt,
+            output_path=out_path,
+            img_path=img_path,
+            img_url=img_url,
+            **kwargs,
+        )
+
+    def _generate_video_mulerouter(self, gen: PlaygroundGeneration, out_path: str) -> None:
+        """Delegate to :class:`MuleRouterVideoModel` (Seedance 2.0)."""
+        from ...models.mulerouter import MuleRouterVideoModel
+
+        if self._mulerouter_video_model is None:
+            self._mulerouter_video_model = MuleRouterVideoModel({})
+
+        params = gen.parameters
+        img_path, img_url = self._resolve_first_input_media(gen)
+
+        kwargs = {
+            "duration": params.get("duration", 5),
+            "resolution": params.get("resolution", "1080p"),
+            "aspect_ratio": params.get("aspect_ratio", "16:9"),
+            "seed": params.get("seed"),
+            "watermark": params.get("watermark", False),
+        }
+
+        # r2v: reference images
+        if gen.mode == PlaygroundMode.R2V and gen.input_media:
+            kwargs["generation_mode"] = "r2v"
+            kwargs["ref_image_urls"] = list(gen.input_media)
+
+        self._mulerouter_video_model.generate(
+            prompt=gen.prompt,
+            output_path=out_path,
+            img_url=img_url,
+            img_path=img_path,
+            **kwargs,
+        )
+
+    def _generate_video_kling(self, gen: PlaygroundGeneration, out_path: str) -> None:
+        """Delegate to :class:`KlingModel`."""
+        from ...models.kling import KlingModel
+
+        if self._kling_model is None:
+            self._kling_model = KlingModel({})
+
+        params = gen.parameters
+        img_path, img_url = self._resolve_first_input_media(gen)
+
+        self._kling_model.generate(
+            prompt=gen.prompt,
+            output_path=out_path,
+            img_url=img_url,
+            img_path=img_path,
+            duration=params.get("duration", 5),
+            model=gen.model_id,
+            negative_prompt=gen.negative_prompt,
+            aspect_ratio=params.get("aspect_ratio", "16:9"),
+            mode=params.get("mode", "std"),
+            sound=params.get("sound", "off"),
+            cfg_scale=params.get("cfg_scale"),
+        )
+
+    def _generate_video_vidu(self, gen: PlaygroundGeneration, out_path: str) -> None:
+        """Delegate to :class:`ViduModel`."""
+        from ...models.vidu import ViduModel
+
+        if self._vidu_model is None:
+            self._vidu_model = ViduModel({})
+
+        params = gen.parameters
+        img_path, img_url = self._resolve_first_input_media(gen)
+
+        self._vidu_model.generate(
+            prompt=gen.prompt,
+            output_path=out_path,
+            img_url=img_url,
+            img_path=img_path,
+            duration=params.get("duration", 5),
+            model=gen.model_id,
+            resolution=params.get("resolution", "720p"),
+            aspect_ratio=params.get("aspect_ratio", "16:9"),
+            seed=params.get("seed", 0),
+            audio=params.get("audio", True),
+            movement_amplitude=params.get("movement_amplitude", "auto"),
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_first_input_media(gen: PlaygroundGeneration):
+        """Return ``(img_path, img_url)`` for the first entry in
+        :pyattr:`input_media`.  Local files are returned as *img_path*;
+        remote URLs as *img_url*."""
+        if not gen.input_media:
+            return None, None
+
+        first = gen.input_media[0]
+        if first.startswith(("http://", "https://")):
+            return None, first
+
+        # Try as-is, then relative to output/
+        if os.path.exists(first):
+            return first, None
+        candidate = os.path.join("output", first)
+        if os.path.exists(candidate):
+            return candidate, None
+
+        # Fall back to treating it as a URL-like reference
+        return None, first

--- a/src/apps/playground/storage.py
+++ b/src/apps/playground/storage.py
@@ -1,0 +1,143 @@
+"""Playground storage layer — JSON-file persistence for generation history and templates."""
+
+import json
+import os
+import threading
+from typing import List, Optional
+
+from .models import PlaygroundGeneration, PlaygroundTemplate
+from ...utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class PlaygroundStorage:
+    HISTORY_PATH = "output/playground_history.json"
+    TEMPLATES_PATH = "output/playground_templates.json"
+
+    def __init__(self):
+        self._history: List[PlaygroundGeneration] = []
+        self._templates: List[PlaygroundTemplate] = []
+        self._lock = threading.RLock()
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Internal persistence
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        """Load both JSON files, creating them if missing."""
+        self._history = self._load_file(self.HISTORY_PATH, PlaygroundGeneration)
+        self._templates = self._load_file(self.TEMPLATES_PATH, PlaygroundTemplate)
+
+    @staticmethod
+    def _load_file(path: str, model_cls):
+        """Read a JSON array file and parse each element into *model_cls*."""
+        if not os.path.exists(path):
+            return []
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+            return [model_cls.model_validate(item) for item in raw]
+        except Exception as e:
+            logger.error("Failed to load %s: %s", path, e)
+            return []
+
+    def _save_history(self) -> None:
+        self._save_file(self.HISTORY_PATH, self._history)
+
+    def _save_templates(self) -> None:
+        self._save_file(self.TEMPLATES_PATH, self._templates)
+
+    def _save_file(self, path: str, items: list) -> None:
+        with self._lock:
+            try:
+                os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(
+                        [item.model_dump() for item in items],
+                        f,
+                        indent=2,
+                        ensure_ascii=False,
+                    )
+            except Exception as e:
+                logger.error("Failed to save %s: %s", path, e)
+
+    # ------------------------------------------------------------------
+    # History CRUD
+    # ------------------------------------------------------------------
+
+    def add_generation(self, gen: PlaygroundGeneration) -> None:
+        """Append a generation record and persist."""
+        self._history.append(gen)
+        self._save_history()
+
+    def get_generation(self, gen_id: str) -> Optional[PlaygroundGeneration]:
+        """Look up a generation by its id."""
+        for gen in self._history:
+            if gen.id == gen_id:
+                return gen
+        return None
+
+    def list_history(
+        self, limit: int = 50, offset: int = 0
+    ) -> List[PlaygroundGeneration]:
+        """Return paginated history, newest first."""
+        ordered = list(reversed(self._history))
+        return ordered[offset : offset + limit]
+
+    def update_generation(self, gen: PlaygroundGeneration) -> None:
+        """Replace an existing generation record (matched by id) and persist."""
+        for i, existing in enumerate(self._history):
+            if existing.id == gen.id:
+                self._history[i] = gen
+                self._save_history()
+                return
+        logger.warning("update_generation: id %s not found", gen.id)
+
+    def delete_generation(self, gen_id: str) -> bool:
+        """Remove a generation by id. Returns True if found and deleted."""
+        for i, gen in enumerate(self._history):
+            if gen.id == gen_id:
+                self._history.pop(i)
+                self._save_history()
+                return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Template CRUD
+    # ------------------------------------------------------------------
+
+    def add_template(self, template: PlaygroundTemplate) -> None:
+        """Append a template record and persist."""
+        self._templates.append(template)
+        self._save_templates()
+
+    def get_template(self, template_id: str) -> Optional[PlaygroundTemplate]:
+        """Look up a template by its id."""
+        for t in self._templates:
+            if t.id == template_id:
+                return t
+        return None
+
+    def list_templates(self) -> List[PlaygroundTemplate]:
+        """Return all templates."""
+        return list(self._templates)
+
+    def update_template(self, template: PlaygroundTemplate) -> None:
+        """Replace an existing template (matched by id) and persist."""
+        for i, existing in enumerate(self._templates):
+            if existing.id == template.id:
+                self._templates[i] = template
+                self._save_templates()
+                return
+        logger.warning("update_template: id %s not found", template.id)
+
+    def delete_template(self, template_id: str) -> bool:
+        """Remove a template by id. Returns True if found and deleted."""
+        for i, t in enumerate(self._templates):
+            if t.id == template_id:
+                self._templates.pop(i)
+                self._save_templates()
+                return True
+        return False

--- a/src/models/wanx.py
+++ b/src/models/wanx.py
@@ -240,8 +240,8 @@ class WanxModel(VideoGenModel):
             logger.info(f"Using T2V model: {final_model_name}")
 
         size = self.params.get('size', '1280*720')
-        prompt_extend = self.params.get('prompt_extend', True)
-        watermark = self.params.get('watermark', False)
+        prompt_extend = kwargs.get('prompt_extend', self.params.get('prompt_extend', True))
+        watermark = kwargs.get('watermark', self.params.get('watermark', False))
 
         # New parameters - prioritize kwargs, fallback to params
         duration = kwargs.get('duration') or self.params.get('duration', 5)


### PR DESCRIPTION
## Summary

Add a full-featured **Playground (创作台)** module — a standalone image/video generation tool independent of the Studio pipeline. Zero-config, instant access from the global sidebar.

### Key Features
- **6 generation modes**: T2I, I2I (merged as "图像"), T2V, I2V, R2V, V2V
- **Two-level mode selector**: 图像生成 / 视频生成 category switch + video sub-mode pills
- **Model-specific dynamic parameters**: each model shows only its supported params (GPT-Image-2: size+quality; Kling: mode+sound+cfgScale; Seedance: seed+watermark; etc.)
- **Concurrent task queue**: users can submit multiple tasks simultaneously, each polled independently
- **Result gallery**: grid/gallery view toggle, session time dividers, filter by type
- **Detail panel**: left-right split (media + metadata/actions), ←→ navigation
- **Prompt templates**: create/apply/delete/favorite, auto-prefill from history
- **Prompt history**: deduplicated, searchable, one-click copy or save as template
- **Failed task handling**: retry button, delete, copy full error text
- **Asset library integration**: save to library (toggle), select from library as input
- **MuleRun one-click login**: in Settings page for Seedance/GPT-Image-2 access

### Model Catalog Changes
- Deprecated Wan 2.6 and below globally (Studio + Playground)
- Added precise `params` declarations for all 27 active models
- Fixed `WanxModel` to read `prompt_extend`/`watermark` from kwargs (was ignoring caller values)
- Fixed PixVerse routing in Playground (was throwing NotImplementedError)
- GPT-Image-2: expanded to 7 sizes including 2K/4K

### Architecture
- Backend: `src/apps/playground/` (FastAPI router, mounted at `/playground/*`)
- Frontend: `frontend/src/components/modules/playground/` (17 component files)
- GlobalSidebar: added "创作台" as 4th nav item
- PRD: `docs/plans/2026-06-06-playground-standalone-generation-prd.md`

## Test plan
- [ ] Navigate to #/playground via sidebar "创作台"
- [ ] Switch between 图像生成 and 视频生成 modes
- [ ] Verify model list changes per mode (correct family ordering)
- [ ] Generate image with GPT-Image-2 (requires MuleRun login)
- [ ] Generate video with Seedance/Kling/Wan 2.7
- [ ] Submit multiple tasks concurrently
- [ ] Verify failed tasks show retry + delete buttons
- [ ] Test prompt template create/apply/favorite/delete
- [ ] Test gallery view mode + detail panel navigation
- [ ] Verify save-to-library toggle syncs across card and detail panel