### PR TITLE
feat(model): HappyHorse 升级 1.0→1.1 (t2v/i2v/r2v)

### DIFF
--- a/config/model_catalog/catalog.meta.yaml
+++ b/config/model_catalog/catalog.meta.yaml
@@ -3,6 +3,6 @@ defaults:
   model_settings:
     t2i_model: wan2.7-image-pro
     i2i_model: wan2.7-image-pro
-    i2v_model: happyhorse-1.0-i2v
-    r2v_model: happyhorse-1.0-r2v
+    i2v_model: happyhorse-1.1-i2v
+    r2v_model: happyhorse-1.1-r2v
     image_model: wan2.7-image-pro

--- a/config/model_catalog/families/happyhorse.yaml
+++ b/config/model_catalog/families/happyhorse.yaml
@@ -3,6 +3,7 @@ display_name: "HappyHorse (快乐马)"
 provider: aliyun
 routing_prefixes:
   - happyhorse-1.0-
+  - happyhorse-1.1-
 supported_backends:
   - dashscope
 default_backend: dashscope
@@ -25,9 +26,9 @@ docs:
   official_snapshot_ids:
     - aliyun/happyhorse/2026-04-28
 models:
-  # Model line: I2V + R2V (paired via modes, like wan/wan2.6-video)
-  - id: happyhorse/happyhorse-1.0-video
-    display_name: HappyHorse 1.0 Video
+  # Model line: I2V + R2V (paired via modes) — upgraded to 1.1
+  - id: happyhorse/happyhorse-1.1-video
+    display_name: HappyHorse 1.1 Video
     description: HappyHorse video generation with I2V and R2V modes
     status: active
     release_stage: stable
@@ -39,7 +40,7 @@ models:
         gateway: dashscope
     modes:
       i2v:
-        legacy_id: happyhorse-1.0-i2v
+        legacy_id: happyhorse-1.1-i2v
         display_name: HappyHorse I2V
         description: Image-to-video with reference character support
         capabilities: [i2v]
@@ -66,7 +67,7 @@ models:
           reference_images:
             max: 9
       r2v:
-        legacy_id: happyhorse-1.0-r2v
+        legacy_id: happyhorse-1.1-r2v
         display_name: HappyHorse R2V
         description: Reference images to video generation
         capabilities: [r2v]
@@ -92,8 +93,8 @@ models:
         inputs:
           reference_images:
             max: 9
-  # Standalone: T2V (hidden)
-  - id: happyhorse-1.0-t2v
+  # Standalone: T2V (hidden) — upgraded to 1.1
+  - id: happyhorse-1.1-t2v
     display_name: HappyHorse T2V
     description: Text-to-video generation (hidden)
     status: hidden
@@ -114,10 +115,10 @@ models:
       negativePrompt: true
       promptExtend: true
       watermark: true
-  # Standalone: V2V (hidden)
+  # Standalone: V2V (hidden) — stays on 1.0 (no 1.1 video-edit yet)
   - id: happyhorse-1.0-video-edit
     display_name: HappyHorse V2V
-    description: Video editing with reference images (hidden)
+    description: Video editing with reference images (hidden, still 1.0)
     status: hidden
     release_stage: stable
     capabilities: [v2v]

--- a/config/model_catalog/generated/model_catalog.json
+++ b/config/model_catalog/generated/model_catalog.json
@@ -2,10 +2,10 @@
   "compat": {
     "legacy_model_ids": {
       "gpt-image-2": "gpt-image/gpt-image-2#image",
-      "happyhorse-1.0-i2v": "happyhorse/happyhorse-1.0-video#i2v",
-      "happyhorse-1.0-r2v": "happyhorse/happyhorse-1.0-video#r2v",
-      "happyhorse-1.0-t2v": "happyhorse/happyhorse-1.0-t2v#i2v",
       "happyhorse-1.0-video-edit": "happyhorse/happyhorse-1.0-video-edit#i2v",
+      "happyhorse-1.1-i2v": "happyhorse/happyhorse-1.1-video#i2v",
+      "happyhorse-1.1-r2v": "happyhorse/happyhorse-1.1-video#r2v",
+      "happyhorse-1.1-t2v": "happyhorse/happyhorse-1.1-t2v#i2v",
       "kling-v3-i2v": "kling/kling-v3-video#i2v",
       "kling-v3-r2v": "kling/kling-v3-video#r2v",
       "pixverse-c1-i2v": "pixverse/pixverse-c1-video#i2v",
@@ -45,16 +45,16 @@
   "defaults": {
     "canonical_model_settings": {
       "i2i_model": "wan/wan2.7-image-pro#image",
-      "i2v_model": "happyhorse/happyhorse-1.0-video#i2v",
+      "i2v_model": "happyhorse/happyhorse-1.1-video#i2v",
       "image_model": "wan/wan2.7-image-pro#image",
-      "r2v_model": "happyhorse/happyhorse-1.0-video#r2v",
+      "r2v_model": "happyhorse/happyhorse-1.1-video#r2v",
       "t2i_model": "wan/wan2.7-image-pro#image"
     },
     "model_settings": {
       "i2i_model": "wan2.7-image-pro",
-      "i2v_model": "happyhorse-1.0-i2v",
+      "i2v_model": "happyhorse-1.1-i2v",
       "image_model": "wan2.7-image-pro",
-      "r2v_model": "happyhorse-1.0-r2v",
+      "r2v_model": "happyhorse-1.1-r2v",
       "t2i_model": "wan2.7-image-pro"
     }
   },
@@ -116,14 +116,15 @@
       },
       "family": "happyhorse",
       "models": [
-        "happyhorse-1.0-i2v",
-        "happyhorse-1.0-r2v",
-        "happyhorse-1.0-t2v",
-        "happyhorse-1.0-video-edit"
+        "happyhorse-1.0-video-edit",
+        "happyhorse-1.1-i2v",
+        "happyhorse-1.1-r2v",
+        "happyhorse-1.1-t2v"
       ],
       "provider": "aliyun",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "supported_backends": [
         "dashscope"
@@ -507,120 +508,6 @@
         }
       }
     },
-    "happyhorse/happyhorse-1.0-t2v": {
-      "backend_env_key": null,
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Text-to-video generation (hidden)",
-      "display_name": "HappyHorse T2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-t2v",
-      "legacy_model_ids": [
-        "happyhorse-1.0-t2v"
-      ],
-      "modes": [
-        "happyhorse/happyhorse-1.0-t2v#i2v"
-      ],
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "runtime": {},
-      "status": "hidden",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "supported_modalities": [
-        "t2v",
-        "i2v",
-        "r2v",
-        "v2v"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      }
-    },
-    "happyhorse/happyhorse-1.0-video": {
-      "backend_env_key": null,
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "HappyHorse video generation with I2V and R2V modes",
-      "display_name": "HappyHorse 1.0 Video",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-video",
-      "legacy_model_ids": [
-        "happyhorse-1.0-i2v",
-        "happyhorse-1.0-r2v"
-      ],
-      "modes": [
-        "happyhorse/happyhorse-1.0-video#i2v",
-        "happyhorse/happyhorse-1.0-video#r2v"
-      ],
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "runtime": {
-        "dashscope": {
-          "gateway": "dashscope"
-        }
-      },
-      "status": "active",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "supported_modalities": [
-        "t2v",
-        "i2v",
-        "r2v",
-        "v2v"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      }
-    },
     "happyhorse/happyhorse-1.0-video-edit": {
       "backend_env_key": null,
       "credential_sources": {
@@ -629,7 +516,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Video editing with reference images (hidden)",
+      "description": "Video editing with reference images (hidden, still 1.0)",
       "display_name": "HappyHorse V2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -650,10 +537,127 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "runtime": {},
       "status": "hidden",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "supported_modalities": [
+        "t2v",
+        "i2v",
+        "r2v",
+        "v2v"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      }
+    },
+    "happyhorse/happyhorse-1.1-t2v": {
+      "backend_env_key": null,
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Text-to-video generation (hidden)",
+      "display_name": "HappyHorse T2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "family": "happyhorse",
+      "id": "happyhorse/happyhorse-1.1-t2v",
+      "legacy_model_ids": [
+        "happyhorse-1.1-t2v"
+      ],
+      "modes": [
+        "happyhorse/happyhorse-1.1-t2v#i2v"
+      ],
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "runtime": {},
+      "status": "hidden",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "supported_modalities": [
+        "t2v",
+        "i2v",
+        "r2v",
+        "v2v"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      }
+    },
+    "happyhorse/happyhorse-1.1-video": {
+      "backend_env_key": null,
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "HappyHorse video generation with I2V and R2V modes",
+      "display_name": "HappyHorse 1.1 Video",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "family": "happyhorse",
+      "id": "happyhorse/happyhorse-1.1-video",
+      "legacy_model_ids": [
+        "happyhorse-1.1-i2v",
+        "happyhorse-1.1-r2v"
+      ],
+      "modes": [
+        "happyhorse/happyhorse-1.1-video#i2v",
+        "happyhorse/happyhorse-1.1-video#r2v"
+      ],
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "runtime": {
+        "dashscope": {
+          "gateway": "dashscope"
+        }
+      },
+      "status": "active",
       "supported_backends": [
         "dashscope"
       ],
@@ -2223,234 +2227,6 @@
         ]
       }
     },
-    "happyhorse-1.0-i2v": {
-      "backend_env_key": null,
-      "capabilities": [
-        "i2v"
-      ],
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Image-to-video with reference character support",
-      "display_name": "HappyHorse I2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "duration": {
-        "default": 5,
-        "max": 15,
-        "min": 3,
-        "step": 1,
-        "type": "slider"
-      },
-      "family": "happyhorse",
-      "id": "happyhorse-1.0-i2v",
-      "inputs": {
-        "reference_images": {
-          "max": 9
-        }
-      },
-      "params": {
-        "negativePrompt": true,
-        "promptExtend": true,
-        "resolution": {
-          "default": "1080p",
-          "options": [
-            "720p",
-            "1080p"
-          ]
-        },
-        "seed": true,
-        "watermark": true
-      },
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "status": "active",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      },
-      "ui": {
-        "badges": [],
-        "order": 120,
-        "recommended": true,
-        "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
-      }
-    },
-    "happyhorse-1.0-r2v": {
-      "backend_env_key": null,
-      "capabilities": [
-        "r2v"
-      ],
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Reference images to video generation",
-      "display_name": "HappyHorse R2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "duration": {
-        "default": 5,
-        "max": 15,
-        "min": 3,
-        "step": 1,
-        "type": "slider"
-      },
-      "family": "happyhorse",
-      "id": "happyhorse-1.0-r2v",
-      "inputs": {
-        "reference_images": {
-          "max": 9
-        }
-      },
-      "params": {
-        "negativePrompt": true,
-        "promptExtend": true,
-        "resolution": {
-          "default": "1080p",
-          "options": [
-            "720p",
-            "1080p"
-          ]
-        },
-        "seed": true,
-        "watermark": true
-      },
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "status": "active",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      },
-      "ui": {
-        "badges": [],
-        "order": 80,
-        "recommended": true,
-        "selection_group": "r2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
-      }
-    },
-    "happyhorse-1.0-t2v": {
-      "backend_env_key": null,
-      "capabilities": [
-        "t2v"
-      ],
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Text-to-video generation (hidden)",
-      "display_name": "HappyHorse T2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "duration": null,
-      "family": "happyhorse",
-      "id": "happyhorse-1.0-t2v",
-      "inputs": {},
-      "params": {
-        "negativePrompt": true,
-        "promptExtend": true,
-        "resolution": {
-          "default": "1080p",
-          "options": [
-            "720p",
-            "1080p"
-          ]
-        },
-        "seed": true,
-        "watermark": true
-      },
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "status": "hidden",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      },
-      "ui": {
-        "badges": [],
-        "order": 0,
-        "recommended": true,
-        "selection_group": "i2v",
-        "visible_in": []
-      }
-    },
     "happyhorse-1.0-video-edit": {
       "backend_env_key": null,
       "capabilities": [
@@ -2462,7 +2238,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Video editing with reference images (hidden)",
+      "description": "Video editing with reference images (hidden, still 1.0)",
       "display_name": "HappyHorse V2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -2492,7 +2268,239 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "status": "hidden",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      },
+      "ui": {
+        "badges": [],
+        "order": 0,
+        "recommended": true,
+        "selection_group": "i2v",
+        "visible_in": []
+      }
+    },
+    "happyhorse-1.1-i2v": {
+      "backend_env_key": null,
+      "capabilities": [
+        "i2v"
+      ],
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Image-to-video with reference character support",
+      "display_name": "HappyHorse I2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "duration": {
+        "default": 5,
+        "max": 15,
+        "min": 3,
+        "step": 1,
+        "type": "slider"
+      },
+      "family": "happyhorse",
+      "id": "happyhorse-1.1-i2v",
+      "inputs": {
+        "reference_images": {
+          "max": 9
+        }
+      },
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "resolution": {
+          "default": "1080p",
+          "options": [
+            "720p",
+            "1080p"
+          ]
+        },
+        "seed": true,
+        "watermark": true
+      },
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "status": "active",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      },
+      "ui": {
+        "badges": [],
+        "order": 120,
+        "recommended": true,
+        "selection_group": "i2v",
+        "visible_in": [
+          "project_settings",
+          "series_settings",
+          "video_sidebar",
+          "global_settings"
+        ]
+      }
+    },
+    "happyhorse-1.1-r2v": {
+      "backend_env_key": null,
+      "capabilities": [
+        "r2v"
+      ],
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Reference images to video generation",
+      "display_name": "HappyHorse R2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "duration": {
+        "default": 5,
+        "max": 15,
+        "min": 3,
+        "step": 1,
+        "type": "slider"
+      },
+      "family": "happyhorse",
+      "id": "happyhorse-1.1-r2v",
+      "inputs": {
+        "reference_images": {
+          "max": 9
+        }
+      },
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "resolution": {
+          "default": "1080p",
+          "options": [
+            "720p",
+            "1080p"
+          ]
+        },
+        "seed": true,
+        "watermark": true
+      },
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "status": "active",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      },
+      "ui": {
+        "badges": [],
+        "order": 80,
+        "recommended": true,
+        "selection_group": "r2v",
+        "visible_in": [
+          "project_settings",
+          "series_settings",
+          "video_sidebar",
+          "global_settings"
+        ]
+      }
+    },
+    "happyhorse-1.1-t2v": {
+      "backend_env_key": null,
+      "capabilities": [
+        "t2v"
+      ],
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Text-to-video generation (hidden)",
+      "display_name": "HappyHorse T2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "duration": null,
+      "family": "happyhorse",
+      "id": "happyhorse-1.1-t2v",
+      "inputs": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "resolution": {
+          "default": "1080p",
+          "options": [
+            "720p",
+            "1080p"
+          ]
+        },
+        "seed": true,
+        "watermark": true
+      },
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "status": "hidden",
       "supported_backends": [
@@ -5268,10 +5276,10 @@
         ]
       }
     },
-    "happyhorse/happyhorse-1.0-t2v#i2v": {
+    "happyhorse/happyhorse-1.0-video-edit#i2v": {
       "backend_env_key": null,
       "capabilities": [
-        "t2v"
+        "v2v"
       ],
       "credential_sources": {
         "dashscope": [
@@ -5279,8 +5287,8 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Text-to-video generation (hidden)",
-      "display_name": "HappyHorse T2V",
+      "description": "Video editing with reference images (hidden, still 1.0)",
+      "display_name": "HappyHorse V2V",
       "docs": {
         "context_hub_doc_ids": [
           "aliyun/happyhorse-video"
@@ -5291,11 +5299,11 @@
       },
       "duration": null,
       "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-t2v#i2v",
+      "id": "happyhorse/happyhorse-1.0-video-edit#i2v",
       "inputs": {},
-      "legacy_model_id": "happyhorse-1.0-t2v",
+      "legacy_model_id": "happyhorse-1.0-video-edit",
       "mode": "i2v",
-      "model_line_id": "happyhorse/happyhorse-1.0-t2v",
+      "model_line_id": "happyhorse/happyhorse-1.0-video-edit",
       "params": {
         "negativePrompt": true,
         "promptExtend": true,
@@ -5312,7 +5320,8 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "runtime": {},
       "status": "hidden",
@@ -5338,7 +5347,78 @@
         "visible_in": []
       }
     },
-    "happyhorse/happyhorse-1.0-video#i2v": {
+    "happyhorse/happyhorse-1.1-t2v#i2v": {
+      "backend_env_key": null,
+      "capabilities": [
+        "t2v"
+      ],
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Text-to-video generation (hidden)",
+      "display_name": "HappyHorse T2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "duration": null,
+      "family": "happyhorse",
+      "id": "happyhorse/happyhorse-1.1-t2v#i2v",
+      "inputs": {},
+      "legacy_model_id": "happyhorse-1.1-t2v",
+      "mode": "i2v",
+      "model_line_id": "happyhorse/happyhorse-1.1-t2v",
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "resolution": {
+          "default": "1080p",
+          "options": [
+            "720p",
+            "1080p"
+          ]
+        },
+        "seed": true,
+        "watermark": true
+      },
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "runtime": {},
+      "status": "hidden",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      },
+      "ui": {
+        "badges": [],
+        "order": 0,
+        "recommended": true,
+        "selection_group": "i2v",
+        "visible_in": []
+      }
+    },
+    "happyhorse/happyhorse-1.1-video#i2v": {
       "backend_env_key": null,
       "capabilities": [
         "i2v"
@@ -5367,15 +5447,15 @@
         "type": "slider"
       },
       "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-video#i2v",
+      "id": "happyhorse/happyhorse-1.1-video#i2v",
       "inputs": {
         "reference_images": {
           "max": 9
         }
       },
-      "legacy_model_id": "happyhorse-1.0-i2v",
+      "legacy_model_id": "happyhorse-1.1-i2v",
       "mode": "i2v",
-      "model_line_id": "happyhorse/happyhorse-1.0-video",
+      "model_line_id": "happyhorse/happyhorse-1.1-video",
       "params": {
         "negativePrompt": true,
         "promptExtend": true,
@@ -5392,7 +5472,8 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "runtime": {
         "dashscope": {
@@ -5427,7 +5508,7 @@
         ]
       }
     },
-    "happyhorse/happyhorse-1.0-video#r2v": {
+    "happyhorse/happyhorse-1.1-video#r2v": {
       "backend_env_key": null,
       "capabilities": [
         "r2v"
@@ -5456,15 +5537,15 @@
         "type": "slider"
       },
       "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-video#r2v",
+      "id": "happyhorse/happyhorse-1.1-video#r2v",
       "inputs": {
         "reference_images": {
           "max": 9
         }
       },
-      "legacy_model_id": "happyhorse-1.0-r2v",
+      "legacy_model_id": "happyhorse-1.1-r2v",
       "mode": "r2v",
-      "model_line_id": "happyhorse/happyhorse-1.0-video",
+      "model_line_id": "happyhorse/happyhorse-1.1-video",
       "params": {
         "negativePrompt": true,
         "promptExtend": true,
@@ -5481,7 +5562,8 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "runtime": {
         "dashscope": {
@@ -5514,76 +5596,6 @@
           "video_sidebar",
           "global_settings"
         ]
-      }
-    },
-    "happyhorse/happyhorse-1.0-video-edit#i2v": {
-      "backend_env_key": null,
-      "capabilities": [
-        "v2v"
-      ],
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Video editing with reference images (hidden)",
-      "display_name": "HappyHorse V2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "duration": null,
-      "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-video-edit#i2v",
-      "inputs": {},
-      "legacy_model_id": "happyhorse-1.0-video-edit",
-      "mode": "i2v",
-      "model_line_id": "happyhorse/happyhorse-1.0-video-edit",
-      "params": {
-        "negativePrompt": true,
-        "promptExtend": true,
-        "resolution": {
-          "default": "1080p",
-          "options": [
-            "720p",
-            "1080p"
-          ]
-        },
-        "seed": true,
-        "watermark": true
-      },
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "runtime": {},
-      "status": "hidden",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      },
-      "ui": {
-        "badges": [],
-        "order": 0,
-        "recommended": true,
-        "selection_group": "i2v",
-        "visible_in": []
       }
     },
     "kling/kling-v3-video#i2v": {

--- a/frontend/src/__tests__/model-catalog.test.ts
+++ b/frontend/src/__tests__/model-catalog.test.ts
@@ -40,7 +40,7 @@ describe('model catalog selectors', () => {
         expect(DEFAULT_MODEL_SETTINGS).toMatchObject({
             t2i_model: 'wan2.7-image-pro',
             i2i_model: 'wan2.7-image-pro',
-            i2v_model: 'happyhorse-1.0-i2v',
+            i2v_model: 'happyhorse-1.1-i2v',
             image_model: 'wan2.7-image-pro',
         });
 
@@ -53,7 +53,7 @@ describe('model catalog selectors', () => {
 
         // Ordered DESC by ui.order; ties broken by display_name asc.
         expect(GLOBAL_I2V_MODELS.map((model) => model.id)).toEqual([
-            'happyhorse-1.0-i2v',
+            'happyhorse-1.1-i2v',
             'kling-v3-i2v',
             'pixverse/pixverse-v6-video',
             'seedance-2.0-i2v',
@@ -84,7 +84,7 @@ describe('model catalog fallbacks', () => {
         ).toMatchObject({
             t2i_model: 'wan2.7-image-pro',
             i2i_model: 'wan2.7-image-pro',
-            i2v_model: 'happyhorse-1.0-i2v',
+            i2v_model: 'happyhorse-1.1-i2v',
         });
     });
 
@@ -139,7 +139,7 @@ describe('model catalog fallbacks', () => {
         // After 524f3a1 deprecated the wan2.6 series, 'wan2.6-i2v' is hidden
         // (visible_in: []), so the canonical → legacy normalization is filtered
         // out by the visibility check and the resolver falls back to the current
-        // i2v default (happyhorse-1.0-i2v). The raw normalization contract is
+        // i2v default (happyhorse-1.1-i2v). The raw normalization contract is
         // covered directly by the Phase 2 canonical helpers below.
         expect(
             resolveCompatModelSettings(
@@ -148,11 +148,11 @@ describe('model catalog fallbacks', () => {
                 },
                 'global_settings'
             ).i2v_model
-        ).toBe('happyhorse-1.0-i2v');
+        ).toBe('happyhorse-1.1-i2v');
 
         // An r2v canonical id normalizes to the matching legacy id
         // (wan2.6-r2v), which is hidden in the i2v surface — so the
-        // resolver falls back to the current i2v default (happyhorse-1.0-i2v
+        // resolver falls back to the current i2v default (happyhorse-1.1-i2v
         // since the 2026-05-26 catalog meta switch). Previously this
         // assertion expected the resolver to remap r2v into the parent
         // i2v legacy id; that behavior was dropped when r2v ids gained
@@ -164,29 +164,29 @@ describe('model catalog fallbacks', () => {
                 },
                 'global_settings'
             ).i2v_model
-        ).toBe('happyhorse-1.0-i2v');
+        ).toBe('happyhorse-1.1-i2v');
 
         expect(compatI2vModels.map((model) => model.id)).not.toContain('wan2.6-i2v');
         expect(compatI2vModels.some((model) => model.id === 'wan/wan2.6-video#i2v')).toBe(false);
         // R2V selection/route ids follow the catalog meta default
-        // (defaults.model_settings.r2v_model = happyhorse-1.0-r2v) via
+        // (defaults.model_settings.r2v_model = happyhorse-1.1-r2v) via
         // getFallbackVisibleModelId, not raw ui.order. Several R2V models
         // share order=80, so anchoring to the explicit meta default keeps the
         // default route deterministic. Selection and route are unified
         // (R2V_ROUTE_MODEL_ID = R2V_SELECTION_MODEL_ID).
-        expect(compatR2vSelectionModelId).toBe('happyhorse-1.0-r2v');
-        expect(compatR2vRouteModelId).toBe('happyhorse-1.0-r2v');
+        expect(compatR2vSelectionModelId).toBe('happyhorse-1.1-r2v');
+        expect(compatR2vRouteModelId).toBe('happyhorse-1.1-r2v');
     });
 });
 
 describe('model catalog runtime helpers', () => {
     it('derives the current R2V selection and route ids from catalog data', () => {
         // Selection and route both resolve to the catalog meta default R2V
-        // model (defaults.model_settings.r2v_model = happyhorse-1.0-r2v) via
+        // model (defaults.model_settings.r2v_model = happyhorse-1.1-r2v) via
         // getFallbackVisibleModelId — deterministic regardless of the order=80
         // tie among visible R2V models (happyhorse/kling/seedance/wan2.7).
-        expect(R2V_SELECTION_MODEL_ID).toBe('happyhorse-1.0-r2v');
-        expect(R2V_ROUTE_MODEL_ID).toBe('happyhorse-1.0-r2v');
+        expect(R2V_SELECTION_MODEL_ID).toBe('happyhorse-1.1-r2v');
+        expect(R2V_ROUTE_MODEL_ID).toBe('happyhorse-1.1-r2v');
     });
 
     it('reads per-model reference image limits from catalog metadata', () => {

--- a/frontend/src/generated/modelCatalog.json
+++ b/frontend/src/generated/modelCatalog.json
@@ -2,10 +2,10 @@
   "compat": {
     "legacy_model_ids": {
       "gpt-image-2": "gpt-image/gpt-image-2#image",
-      "happyhorse-1.0-i2v": "happyhorse/happyhorse-1.0-video#i2v",
-      "happyhorse-1.0-r2v": "happyhorse/happyhorse-1.0-video#r2v",
-      "happyhorse-1.0-t2v": "happyhorse/happyhorse-1.0-t2v#i2v",
       "happyhorse-1.0-video-edit": "happyhorse/happyhorse-1.0-video-edit#i2v",
+      "happyhorse-1.1-i2v": "happyhorse/happyhorse-1.1-video#i2v",
+      "happyhorse-1.1-r2v": "happyhorse/happyhorse-1.1-video#r2v",
+      "happyhorse-1.1-t2v": "happyhorse/happyhorse-1.1-t2v#i2v",
       "kling-v3-i2v": "kling/kling-v3-video#i2v",
       "kling-v3-r2v": "kling/kling-v3-video#r2v",
       "pixverse-c1-i2v": "pixverse/pixverse-c1-video#i2v",
@@ -45,16 +45,16 @@
   "defaults": {
     "canonical_model_settings": {
       "i2i_model": "wan/wan2.7-image-pro#image",
-      "i2v_model": "happyhorse/happyhorse-1.0-video#i2v",
+      "i2v_model": "happyhorse/happyhorse-1.1-video#i2v",
       "image_model": "wan/wan2.7-image-pro#image",
-      "r2v_model": "happyhorse/happyhorse-1.0-video#r2v",
+      "r2v_model": "happyhorse/happyhorse-1.1-video#r2v",
       "t2i_model": "wan/wan2.7-image-pro#image"
     },
     "model_settings": {
       "i2i_model": "wan2.7-image-pro",
-      "i2v_model": "happyhorse-1.0-i2v",
+      "i2v_model": "happyhorse-1.1-i2v",
       "image_model": "wan2.7-image-pro",
-      "r2v_model": "happyhorse-1.0-r2v",
+      "r2v_model": "happyhorse-1.1-r2v",
       "t2i_model": "wan2.7-image-pro"
     }
   },
@@ -116,14 +116,15 @@
       },
       "family": "happyhorse",
       "models": [
-        "happyhorse-1.0-i2v",
-        "happyhorse-1.0-r2v",
-        "happyhorse-1.0-t2v",
-        "happyhorse-1.0-video-edit"
+        "happyhorse-1.0-video-edit",
+        "happyhorse-1.1-i2v",
+        "happyhorse-1.1-r2v",
+        "happyhorse-1.1-t2v"
       ],
       "provider": "aliyun",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "supported_backends": [
         "dashscope"
@@ -507,120 +508,6 @@
         }
       }
     },
-    "happyhorse/happyhorse-1.0-t2v": {
-      "backend_env_key": null,
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Text-to-video generation (hidden)",
-      "display_name": "HappyHorse T2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-t2v",
-      "legacy_model_ids": [
-        "happyhorse-1.0-t2v"
-      ],
-      "modes": [
-        "happyhorse/happyhorse-1.0-t2v#i2v"
-      ],
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "runtime": {},
-      "status": "hidden",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "supported_modalities": [
-        "t2v",
-        "i2v",
-        "r2v",
-        "v2v"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      }
-    },
-    "happyhorse/happyhorse-1.0-video": {
-      "backend_env_key": null,
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "HappyHorse video generation with I2V and R2V modes",
-      "display_name": "HappyHorse 1.0 Video",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-video",
-      "legacy_model_ids": [
-        "happyhorse-1.0-i2v",
-        "happyhorse-1.0-r2v"
-      ],
-      "modes": [
-        "happyhorse/happyhorse-1.0-video#i2v",
-        "happyhorse/happyhorse-1.0-video#r2v"
-      ],
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "runtime": {
-        "dashscope": {
-          "gateway": "dashscope"
-        }
-      },
-      "status": "active",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "supported_modalities": [
-        "t2v",
-        "i2v",
-        "r2v",
-        "v2v"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      }
-    },
     "happyhorse/happyhorse-1.0-video-edit": {
       "backend_env_key": null,
       "credential_sources": {
@@ -629,7 +516,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Video editing with reference images (hidden)",
+      "description": "Video editing with reference images (hidden, still 1.0)",
       "display_name": "HappyHorse V2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -650,10 +537,127 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "runtime": {},
       "status": "hidden",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "supported_modalities": [
+        "t2v",
+        "i2v",
+        "r2v",
+        "v2v"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      }
+    },
+    "happyhorse/happyhorse-1.1-t2v": {
+      "backend_env_key": null,
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Text-to-video generation (hidden)",
+      "display_name": "HappyHorse T2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "family": "happyhorse",
+      "id": "happyhorse/happyhorse-1.1-t2v",
+      "legacy_model_ids": [
+        "happyhorse-1.1-t2v"
+      ],
+      "modes": [
+        "happyhorse/happyhorse-1.1-t2v#i2v"
+      ],
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "runtime": {},
+      "status": "hidden",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "supported_modalities": [
+        "t2v",
+        "i2v",
+        "r2v",
+        "v2v"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      }
+    },
+    "happyhorse/happyhorse-1.1-video": {
+      "backend_env_key": null,
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "HappyHorse video generation with I2V and R2V modes",
+      "display_name": "HappyHorse 1.1 Video",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "family": "happyhorse",
+      "id": "happyhorse/happyhorse-1.1-video",
+      "legacy_model_ids": [
+        "happyhorse-1.1-i2v",
+        "happyhorse-1.1-r2v"
+      ],
+      "modes": [
+        "happyhorse/happyhorse-1.1-video#i2v",
+        "happyhorse/happyhorse-1.1-video#r2v"
+      ],
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "runtime": {
+        "dashscope": {
+          "gateway": "dashscope"
+        }
+      },
+      "status": "active",
       "supported_backends": [
         "dashscope"
       ],
@@ -2223,234 +2227,6 @@
         ]
       }
     },
-    "happyhorse-1.0-i2v": {
-      "backend_env_key": null,
-      "capabilities": [
-        "i2v"
-      ],
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Image-to-video with reference character support",
-      "display_name": "HappyHorse I2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "duration": {
-        "default": 5,
-        "max": 15,
-        "min": 3,
-        "step": 1,
-        "type": "slider"
-      },
-      "family": "happyhorse",
-      "id": "happyhorse-1.0-i2v",
-      "inputs": {
-        "reference_images": {
-          "max": 9
-        }
-      },
-      "params": {
-        "negativePrompt": true,
-        "promptExtend": true,
-        "resolution": {
-          "default": "1080p",
-          "options": [
-            "720p",
-            "1080p"
-          ]
-        },
-        "seed": true,
-        "watermark": true
-      },
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "status": "active",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      },
-      "ui": {
-        "badges": [],
-        "order": 120,
-        "recommended": true,
-        "selection_group": "i2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
-      }
-    },
-    "happyhorse-1.0-r2v": {
-      "backend_env_key": null,
-      "capabilities": [
-        "r2v"
-      ],
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Reference images to video generation",
-      "display_name": "HappyHorse R2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "duration": {
-        "default": 5,
-        "max": 15,
-        "min": 3,
-        "step": 1,
-        "type": "slider"
-      },
-      "family": "happyhorse",
-      "id": "happyhorse-1.0-r2v",
-      "inputs": {
-        "reference_images": {
-          "max": 9
-        }
-      },
-      "params": {
-        "negativePrompt": true,
-        "promptExtend": true,
-        "resolution": {
-          "default": "1080p",
-          "options": [
-            "720p",
-            "1080p"
-          ]
-        },
-        "seed": true,
-        "watermark": true
-      },
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "status": "active",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      },
-      "ui": {
-        "badges": [],
-        "order": 80,
-        "recommended": true,
-        "selection_group": "r2v",
-        "visible_in": [
-          "project_settings",
-          "series_settings",
-          "video_sidebar",
-          "global_settings"
-        ]
-      }
-    },
-    "happyhorse-1.0-t2v": {
-      "backend_env_key": null,
-      "capabilities": [
-        "t2v"
-      ],
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Text-to-video generation (hidden)",
-      "display_name": "HappyHorse T2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "duration": null,
-      "family": "happyhorse",
-      "id": "happyhorse-1.0-t2v",
-      "inputs": {},
-      "params": {
-        "negativePrompt": true,
-        "promptExtend": true,
-        "resolution": {
-          "default": "1080p",
-          "options": [
-            "720p",
-            "1080p"
-          ]
-        },
-        "seed": true,
-        "watermark": true
-      },
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "status": "hidden",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      },
-      "ui": {
-        "badges": [],
-        "order": 0,
-        "recommended": true,
-        "selection_group": "i2v",
-        "visible_in": []
-      }
-    },
     "happyhorse-1.0-video-edit": {
       "backend_env_key": null,
       "capabilities": [
@@ -2462,7 +2238,7 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Video editing with reference images (hidden)",
+      "description": "Video editing with reference images (hidden, still 1.0)",
       "display_name": "HappyHorse V2V",
       "docs": {
         "context_hub_doc_ids": [
@@ -2492,7 +2268,239 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "status": "hidden",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      },
+      "ui": {
+        "badges": [],
+        "order": 0,
+        "recommended": true,
+        "selection_group": "i2v",
+        "visible_in": []
+      }
+    },
+    "happyhorse-1.1-i2v": {
+      "backend_env_key": null,
+      "capabilities": [
+        "i2v"
+      ],
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Image-to-video with reference character support",
+      "display_name": "HappyHorse I2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "duration": {
+        "default": 5,
+        "max": 15,
+        "min": 3,
+        "step": 1,
+        "type": "slider"
+      },
+      "family": "happyhorse",
+      "id": "happyhorse-1.1-i2v",
+      "inputs": {
+        "reference_images": {
+          "max": 9
+        }
+      },
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "resolution": {
+          "default": "1080p",
+          "options": [
+            "720p",
+            "1080p"
+          ]
+        },
+        "seed": true,
+        "watermark": true
+      },
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "status": "active",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      },
+      "ui": {
+        "badges": [],
+        "order": 120,
+        "recommended": true,
+        "selection_group": "i2v",
+        "visible_in": [
+          "project_settings",
+          "series_settings",
+          "video_sidebar",
+          "global_settings"
+        ]
+      }
+    },
+    "happyhorse-1.1-r2v": {
+      "backend_env_key": null,
+      "capabilities": [
+        "r2v"
+      ],
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Reference images to video generation",
+      "display_name": "HappyHorse R2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "duration": {
+        "default": 5,
+        "max": 15,
+        "min": 3,
+        "step": 1,
+        "type": "slider"
+      },
+      "family": "happyhorse",
+      "id": "happyhorse-1.1-r2v",
+      "inputs": {
+        "reference_images": {
+          "max": 9
+        }
+      },
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "resolution": {
+          "default": "1080p",
+          "options": [
+            "720p",
+            "1080p"
+          ]
+        },
+        "seed": true,
+        "watermark": true
+      },
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "status": "active",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      },
+      "ui": {
+        "badges": [],
+        "order": 80,
+        "recommended": true,
+        "selection_group": "r2v",
+        "visible_in": [
+          "project_settings",
+          "series_settings",
+          "video_sidebar",
+          "global_settings"
+        ]
+      }
+    },
+    "happyhorse-1.1-t2v": {
+      "backend_env_key": null,
+      "capabilities": [
+        "t2v"
+      ],
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Text-to-video generation (hidden)",
+      "display_name": "HappyHorse T2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "duration": null,
+      "family": "happyhorse",
+      "id": "happyhorse-1.1-t2v",
+      "inputs": {},
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "resolution": {
+          "default": "1080p",
+          "options": [
+            "720p",
+            "1080p"
+          ]
+        },
+        "seed": true,
+        "watermark": true
+      },
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "status": "hidden",
       "supported_backends": [
@@ -5268,10 +5276,10 @@
         ]
       }
     },
-    "happyhorse/happyhorse-1.0-t2v#i2v": {
+    "happyhorse/happyhorse-1.0-video-edit#i2v": {
       "backend_env_key": null,
       "capabilities": [
-        "t2v"
+        "v2v"
       ],
       "credential_sources": {
         "dashscope": [
@@ -5279,8 +5287,8 @@
         ]
       },
       "default_backend": "dashscope",
-      "description": "Text-to-video generation (hidden)",
-      "display_name": "HappyHorse T2V",
+      "description": "Video editing with reference images (hidden, still 1.0)",
+      "display_name": "HappyHorse V2V",
       "docs": {
         "context_hub_doc_ids": [
           "aliyun/happyhorse-video"
@@ -5291,11 +5299,11 @@
       },
       "duration": null,
       "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-t2v#i2v",
+      "id": "happyhorse/happyhorse-1.0-video-edit#i2v",
       "inputs": {},
-      "legacy_model_id": "happyhorse-1.0-t2v",
+      "legacy_model_id": "happyhorse-1.0-video-edit",
       "mode": "i2v",
-      "model_line_id": "happyhorse/happyhorse-1.0-t2v",
+      "model_line_id": "happyhorse/happyhorse-1.0-video-edit",
       "params": {
         "negativePrompt": true,
         "promptExtend": true,
@@ -5312,7 +5320,8 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "runtime": {},
       "status": "hidden",
@@ -5338,7 +5347,78 @@
         "visible_in": []
       }
     },
-    "happyhorse/happyhorse-1.0-video#i2v": {
+    "happyhorse/happyhorse-1.1-t2v#i2v": {
+      "backend_env_key": null,
+      "capabilities": [
+        "t2v"
+      ],
+      "credential_sources": {
+        "dashscope": [
+          "DASHSCOPE_API_KEY"
+        ]
+      },
+      "default_backend": "dashscope",
+      "description": "Text-to-video generation (hidden)",
+      "display_name": "HappyHorse T2V",
+      "docs": {
+        "context_hub_doc_ids": [
+          "aliyun/happyhorse-video"
+        ],
+        "official_snapshot_ids": [
+          "aliyun/happyhorse/2026-04-28"
+        ]
+      },
+      "duration": null,
+      "family": "happyhorse",
+      "id": "happyhorse/happyhorse-1.1-t2v#i2v",
+      "inputs": {},
+      "legacy_model_id": "happyhorse-1.1-t2v",
+      "mode": "i2v",
+      "model_line_id": "happyhorse/happyhorse-1.1-t2v",
+      "params": {
+        "negativePrompt": true,
+        "promptExtend": true,
+        "resolution": {
+          "default": "1080p",
+          "options": [
+            "720p",
+            "1080p"
+          ]
+        },
+        "seed": true,
+        "watermark": true
+      },
+      "provider": "aliyun",
+      "release_stage": "stable",
+      "routing_prefixes": [
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
+      ],
+      "runtime": {},
+      "status": "hidden",
+      "supported_backends": [
+        "dashscope"
+      ],
+      "transport": {
+        "audio_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "image_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        },
+        "reference_video_input_mode": {
+          "dashscope": "dashscope_temp_file_url"
+        }
+      },
+      "ui": {
+        "badges": [],
+        "order": 0,
+        "recommended": true,
+        "selection_group": "i2v",
+        "visible_in": []
+      }
+    },
+    "happyhorse/happyhorse-1.1-video#i2v": {
       "backend_env_key": null,
       "capabilities": [
         "i2v"
@@ -5367,15 +5447,15 @@
         "type": "slider"
       },
       "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-video#i2v",
+      "id": "happyhorse/happyhorse-1.1-video#i2v",
       "inputs": {
         "reference_images": {
           "max": 9
         }
       },
-      "legacy_model_id": "happyhorse-1.0-i2v",
+      "legacy_model_id": "happyhorse-1.1-i2v",
       "mode": "i2v",
-      "model_line_id": "happyhorse/happyhorse-1.0-video",
+      "model_line_id": "happyhorse/happyhorse-1.1-video",
       "params": {
         "negativePrompt": true,
         "promptExtend": true,
@@ -5392,7 +5472,8 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "runtime": {
         "dashscope": {
@@ -5427,7 +5508,7 @@
         ]
       }
     },
-    "happyhorse/happyhorse-1.0-video#r2v": {
+    "happyhorse/happyhorse-1.1-video#r2v": {
       "backend_env_key": null,
       "capabilities": [
         "r2v"
@@ -5456,15 +5537,15 @@
         "type": "slider"
       },
       "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-video#r2v",
+      "id": "happyhorse/happyhorse-1.1-video#r2v",
       "inputs": {
         "reference_images": {
           "max": 9
         }
       },
-      "legacy_model_id": "happyhorse-1.0-r2v",
+      "legacy_model_id": "happyhorse-1.1-r2v",
       "mode": "r2v",
-      "model_line_id": "happyhorse/happyhorse-1.0-video",
+      "model_line_id": "happyhorse/happyhorse-1.1-video",
       "params": {
         "negativePrompt": true,
         "promptExtend": true,
@@ -5481,7 +5562,8 @@
       "provider": "aliyun",
       "release_stage": "stable",
       "routing_prefixes": [
-        "happyhorse-1.0-"
+        "happyhorse-1.0-",
+        "happyhorse-1.1-"
       ],
       "runtime": {
         "dashscope": {
@@ -5514,76 +5596,6 @@
           "video_sidebar",
           "global_settings"
         ]
-      }
-    },
-    "happyhorse/happyhorse-1.0-video-edit#i2v": {
-      "backend_env_key": null,
-      "capabilities": [
-        "v2v"
-      ],
-      "credential_sources": {
-        "dashscope": [
-          "DASHSCOPE_API_KEY"
-        ]
-      },
-      "default_backend": "dashscope",
-      "description": "Video editing with reference images (hidden)",
-      "display_name": "HappyHorse V2V",
-      "docs": {
-        "context_hub_doc_ids": [
-          "aliyun/happyhorse-video"
-        ],
-        "official_snapshot_ids": [
-          "aliyun/happyhorse/2026-04-28"
-        ]
-      },
-      "duration": null,
-      "family": "happyhorse",
-      "id": "happyhorse/happyhorse-1.0-video-edit#i2v",
-      "inputs": {},
-      "legacy_model_id": "happyhorse-1.0-video-edit",
-      "mode": "i2v",
-      "model_line_id": "happyhorse/happyhorse-1.0-video-edit",
-      "params": {
-        "negativePrompt": true,
-        "promptExtend": true,
-        "resolution": {
-          "default": "1080p",
-          "options": [
-            "720p",
-            "1080p"
-          ]
-        },
-        "seed": true,
-        "watermark": true
-      },
-      "provider": "aliyun",
-      "release_stage": "stable",
-      "routing_prefixes": [
-        "happyhorse-1.0-"
-      ],
-      "runtime": {},
-      "status": "hidden",
-      "supported_backends": [
-        "dashscope"
-      ],
-      "transport": {
-        "audio_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "image_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        },
-        "reference_video_input_mode": {
-          "dashscope": "dashscope_temp_file_url"
-        }
-      },
-      "ui": {
-        "badges": [],
-        "order": 0,
-        "recommended": true,
-        "selection_group": "i2v",
-        "visible_in": []
       }
     },
     "kling/kling-v3-video#i2v": {

--- a/src/apps/comic_gen/pipeline.py
+++ b/src/apps/comic_gen/pipeline.py
@@ -2089,7 +2089,7 @@ class ComicGenPipeline:
             # Skip auto-switch if user already selected an R2V model directly
             if not (model and model.endswith("-r2v")):
                 if model and model.startswith("happyhorse-"):
-                    model = "happyhorse-1.0-r2v"
+                    model = "happyhorse-1.1-r2v"
                 elif model and model.startswith("wan2.7-"):
                     model = "wan2.7-r2v"
                 elif model and model.startswith("kling"):


### PR DESCRIPTION
## Context

HappyHorse 发布新一代 1.1 模型，将 t2v / i2v / r2v 从 1.0 升级到 1.1。V2V (video-edit) 暂无 1.1 版本，沿用 1.0。

## 改动

| 模式 | 之前 | 现在 |
|---|---|---|
| I2V | happyhorse-1.0-i2v | happyhorse-1.1-i2v |
| R2V | happyhorse-1.0-r2v | happyhorse-1.1-r2v |
| T2V | happyhorse-1.0-t2v | happyhorse-1.1-t2v |
| V2V (video-edit) | happyhorse-1.0-video-edit | 沿用 1.0（无 1.1） |

- `config/model_catalog/families/happyhorse.yaml`：i2v/r2v/t2v 升 1.1，v2v 保留 1.0，routing_prefixes 加 `happyhorse-1.1-`
- `config/model_catalog/catalog.meta.yaml`：i2v/r2v 默认 → 1.1
- `src/apps/comic_gen/pipeline.py`：R2V fallback `happyhorse-1.0-r2v` → `happyhorse-1.1-r2v`
- 重新生成 `generated/model_catalog.json` + `frontend/src/generated/modelCatalog.json`
- `model-catalog.test.ts` 断言更新 1.1

## 验证

- ✅ `python scripts/validate_model_catalog.py`
- ✅ `npm run typecheck`
- ✅ `npm run check:colors`
- ✅ `npm run test`（124/124）

## 注意

- 既有项目的 `model_settings.r2v_model` 若已存为 `happyhorse-1.0-r2v`，resolveModelId 会 fallback 到 catalog 默认（1.1）或标记 deprecated；建议在生成设置里重新选一次 1.1 持久化。