### PR TITLE
fix: remove committed developer-local 'output' symlink

### DIFF
--- a/output
+++ b/output
@@ -1,1 +1,0 @@
-/Users/hoshinoren/Documents/code/project/video_gen/gitlab/tron-comic/output


### PR DESCRIPTION
修复 #41 中的问题 1：移除被提交进仓库的 `output` 软链。

该条目指向开发者本机路径（`/Users/hoshinoren/.../tron-comic/output`），在任何其他机器上都是死链，导致后端启动时 `os.makedirs("output", exist_ok=True)` 抛 `FileExistsError`（路径存在但不是目录），uvicorn 直接退出。

- `.gitignore` 第 93 行已有 `output/` 规则，删除跟踪后不会再被意外提交
- `src/apps/comic_gen/api.py` 启动时会自行创建该目录，无需在仓库中保留任何占位

#41 中的问题 2（lockfile 指向内网 registry）建议由维护者在公网环境重新生成 lockfile 修复，不在本 PR 范围内。
