### PR TITLE
fix: allow relative upload paths in library asset image field

### DIFF
--- a/frontend/src/components/library/NewLibraryAssetDialog.tsx
+++ b/frontend/src/components/library/NewLibraryAssetDialog.tsx
@@ -252,7 +252,7 @@ export default function NewLibraryAssetDialog({ onClose, onCreated }: NewLibrary
             </label>
             <input
               id="lib-asset-image"
-              type="url"
+              type="text"
               value={imageUrl}
               onChange={(e) => setImageUrl(e.target.value)}
               placeholder={t("imageUrlPlaceholder")}


### PR DESCRIPTION
## Summary
- Fix the "新建全局资产" dialog blocking creation after a local image upload: the image URL input used `type="url"`, so the browser's native form validation rejected the relative path (`uploads/<uuid>.png`) returned by `/library/assets/upload` in local (non-OSS) mode and showed "请输入网址。", preventing form submission entirely.
- Change the input to `type="text"` so both uploaded local relative paths and pasted absolute URLs are accepted; both flows feed the same `image_url` field, no backend change needed.

## Test plan
- [ ] Open Asset Library → 新建全局资产, upload a local image (without OSS configured), click 创建 → asset is created with the uploaded image, no browser validation bubble
- [ ] Paste an absolute image URL instead of uploading → creation still works
- [ ] Leave image empty → creation still works (image optional)