### PR TITLE
fix(security): make defusedxml a hard dependency in _parse_fdx (closes CodeQL alert #44)

### DIFF
--- a/src/apps/comic_gen/api.py
+++ b/src/apps/comic_gen/api.py
@@ -4154,14 +4154,13 @@ def _parse_fdx(xml_text: str) -> dict:
     import re
     from xml.etree.ElementTree import ParseError
 
-    try:
-        # defusedxml guards against entity-expansion attacks (XML bomb)
-        from defusedxml.ElementTree import fromstring as _xml_fromstring
-    except ImportError:
-        from xml.etree.ElementTree import fromstring as _xml_fromstring
+    # defusedxml guards against entity-expansion attacks (XML bomb).
+    # Hard dependency (declared in requirements.txt) so the parse path is
+    # always the hardened one; no stdlib fallback.
+    from defusedxml.ElementTree import fromstring as _xml_fromstring
 
-    # Reject DTD/entity declarations outright (defense-in-depth for the
-    # stdlib fallback; FDX files never legitimately contain them)
+    # Reject DTD/entity declarations outright (defense-in-depth;
+    # FDX files never legitimately contain them)
     if "<!DOCTYPE" in xml_text or "<!ENTITY" in xml_text:
         raise HTTPException(status_code=400, detail="FDX XML with DTD/entity declarations is not allowed")
 


### PR DESCRIPTION
## Why

CodeQL alert #44 (`py/xml-bomb`, high) remained **open on main** after PR #49's security fix (8b78b78). Root cause: the `py/xml-bomb` query does not credit the `try/except ImportError` defusedxml fallback pattern — the stdlib `fromstring` fallback path is still statically reachable, so the alert stays open.

## What

- Remove the stdlib fallback in `_parse_fdx`; import `defusedxml.ElementTree.fromstring` unconditionally (hard dependency, already declared in `requirements.txt` as `defusedxml>=0.7.1`)
- Keep the `<!DOCTYPE`/`<!ENTITY` string guard as defense-in-depth

## Verification

- `ast.parse` syntax check ✅
- Valid FDX → identical Tiptap node sequence (`sceneHeading/characterCue/dialogue`) ✅
- XML-bomb payload rejected with HTTP 400 ✅
- Malformed XML rejected with HTTP 400 ✅
- `defusedxml 0.7.1` confirmed importable in the backend runtime env ✅