### PR TITLE
Add MiniMax text-to-audio provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # 阿里云 DashScope API Key (用于通义千问等模型)
 DASHSCOPE_API_KEY=your_dashscope_api_key_here
+MINIMAX_API_KEY=your_minimax_api_key_here
+MINIMAX_API_REGION=global
 
 # 阿里云 Access Key (用于 OSS、视频超分等服务)
 ALIBABA_CLOUD_ACCESS_KEY_ID=your_aliyun_access_key_id_here

--- a/src/audio/minimax_tts.py
+++ b/src/audio/minimax_tts.py
@@ -1,0 +1,139 @@
+"""MiniMax text-to-audio HTTP client."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import requests
+
+MINIMAX_TTS_ENDPOINTS = {
+    "global": "https://api.minimax.io/v1/t2a_v2",
+    "cn": "https://api.minimaxi.com/v1/t2a_v2",
+}
+
+MINIMAX_TTS_MODELS = (
+    "speech-2.8-hd",
+    "speech-2.8-turbo",
+    "speech-2.6-hd",
+    "speech-2.6-turbo",
+    "speech-02-hd",
+    "speech-02-turbo",
+    "speech-01-hd",
+    "speech-01-turbo",
+)
+
+MINIMAX_AUDIO_FORMATS = ("mp3", "wav", "flac", "pcm")
+MINIMAX_OUTPUT_FORMATS = ("hex", "url")
+
+
+class MiniMaxTTSClient:
+    """Generate speech with the MiniMax non-streaming HTTP API."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        region: str = "global",
+        timeout: float = 60.0,
+    ) -> None:
+        self.api_key = api_key or os.getenv("MINIMAX_API_KEY")
+        if not self.api_key:
+            raise ValueError("MINIMAX_API_KEY is required for speech synthesis")
+
+        normalized_region = region.strip().lower()
+        if normalized_region not in MINIMAX_TTS_ENDPOINTS:
+            choices = ", ".join(MINIMAX_TTS_ENDPOINTS)
+            raise ValueError(f"Unsupported MiniMax region '{region}'; choose {choices}")
+
+        self.endpoint = MINIMAX_TTS_ENDPOINTS[normalized_region]
+        self.timeout = timeout
+
+    def synthesize(
+        self,
+        text: str,
+        output_path: str,
+        *,
+        model: str = MINIMAX_TTS_MODELS[0],
+        stream: bool = False,
+        language_boost: str | None = None,
+        output_format: str = "hex",
+        voice_setting: Mapping[str, Any] | None = None,
+        pronunciation_dict: Mapping[str, Any] | None = None,
+        audio_setting: Mapping[str, Any] | None = None,
+        voice_modify: Mapping[str, Any] | None = None,
+        subtitle_enable: bool | None = None,
+    ) -> tuple[str, float, str]:
+        """Synthesize ``text`` and save the completed audio response."""
+        if not text:
+            raise ValueError("Text is required for MiniMax speech synthesis")
+        if model not in MINIMAX_TTS_MODELS:
+            raise ValueError(f"Unsupported MiniMax speech model '{model}'")
+        if stream:
+            raise ValueError("Streaming MiniMax speech responses cannot be saved directly")
+        if output_format not in MINIMAX_OUTPUT_FORMATS:
+            raise ValueError(f"Unsupported MiniMax output format '{output_format}'")
+
+        normalized_audio_setting = dict(audio_setting or {})
+        audio_format = normalized_audio_setting.get("format", "mp3")
+        if audio_format not in MINIMAX_AUDIO_FORMATS:
+            raise ValueError(f"Unsupported MiniMax audio format '{audio_format}'")
+        normalized_audio_setting.setdefault("format", audio_format)
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "text": text,
+            "stream": False,
+            "output_format": output_format,
+            "audio_setting": normalized_audio_setting,
+        }
+        optional_fields = {
+            "language_boost": language_boost,
+            "voice_setting": voice_setting,
+            "pronunciation_dict": pronunciation_dict,
+            "voice_modify": voice_modify,
+            "subtitle_enable": subtitle_enable,
+        }
+        payload.update(
+            {name: value for name, value in optional_fields.items() if value is not None}
+        )
+
+        response = requests.post(
+            self.endpoint,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        base_response = result.get("base_resp") or {}
+        if base_response.get("status_code") != 0:
+            message = base_response.get("status_msg") or "unknown API error"
+            raise RuntimeError(f"MiniMax speech synthesis failed: {message}")
+
+        data = result.get("data") or {}
+        if data.get("status") != 2:
+            raise RuntimeError("MiniMax speech synthesis did not complete")
+        audio_value = data.get("audio")
+        if not audio_value:
+            raise RuntimeError("MiniMax speech response did not include audio")
+
+        if output_format == "hex":
+            try:
+                audio_bytes = bytes.fromhex(audio_value)
+            except ValueError as exc:
+                raise RuntimeError("MiniMax speech response contained invalid hex audio") from exc
+        else:
+            audio_response = requests.get(audio_value, timeout=self.timeout)
+            audio_response.raise_for_status()
+            audio_bytes = audio_response.content
+
+        destination = Path(output_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(audio_bytes)
+        return str(destination), 0.0, str(result.get("trace_id") or "")

--- a/src/audio/tts.py
+++ b/src/audio/tts.py
@@ -115,7 +115,9 @@ class TTSProcessor:
         self,
         api_key: Optional[str] = None,
         model: str = "cosyvoice-v3-flash",
-        voice: str = "longanyang"
+        voice: str = "longanyang",
+        minimax_api_key: Optional[str] = None,
+        minimax_region: Optional[str] = None,
     ):
         """
         Initialize TTS processor
@@ -124,6 +126,8 @@ class TTSProcessor:
             api_key: DashScope API key. If None, will read from DASHSCOPE_API_KEY env var
             model: TTS model name (default: cosyvoice-v2)
             voice: Default voice ID (default: longxiaochun_v2)
+            minimax_api_key: MiniMax API key. Defaults to MINIMAX_API_KEY
+            minimax_region: MiniMax API region (global or cn)
         """
         import dashscope
 
@@ -133,6 +137,8 @@ class TTSProcessor:
 
         self.model = model
         self.voice = voice
+        self.minimax_api_key = minimax_api_key or os.getenv('MINIMAX_API_KEY')
+        self.minimax_region = minimax_region or os.getenv('MINIMAX_API_REGION', 'global')
 
         logger.info(f"TTS Processor initialized with model={model}, voice={voice}")
 
@@ -165,7 +171,7 @@ class TTSProcessor:
                 otherwise. PR-3g #2.
             model_override: Force a specific TTS model (e.g. cosyvoice-v3.5-plus
                 for custom cloned voices not in TTS_VOICE_REGISTRY). PR-3h #2.
-            family_override: Force dispatch family ('cosyvoice' | 'qwen3') for
+            family_override: Force a dispatch family for
                 voices not in the registry. PR-3h #2.
 
         Returns:
@@ -174,6 +180,12 @@ class TTSProcessor:
         voice = voice or self.voice
         family = family_override or self._resolve_family_for_voice(voice)
 
+        if family == 'minimax':
+            return self._synthesize_minimax(
+                text, output_path, voice,
+                speech_rate=speech_rate, volume=volume,
+                model_override=model_override,
+            )
         if family == 'qwen3':
             return self._synthesize_qwen3(
                 text, output_path, voice,
@@ -326,6 +338,36 @@ class TTSProcessor:
         )
         # Qwen3 non-streaming has no first_package_delay; report 0.
         return output_path, 0.0, request_id
+
+    def _synthesize_minimax(
+        self, text: str, output_path: str, voice: str,
+        speech_rate: float = 1.0, volume: int = 50,
+        model_override: Optional[str] = None,
+    ) -> Tuple[str, float, str]:
+        """Synthesize speech through the MiniMax HTTP API."""
+        from .minimax_tts import MINIMAX_AUDIO_FORMATS, MINIMAX_TTS_MODELS, MiniMaxTTSClient
+
+        model = model_override or (
+            self.model if self.model in MINIMAX_TTS_MODELS else MINIMAX_TTS_MODELS[0]
+        )
+        extension = os.path.splitext(output_path)[1].lstrip('.').lower()
+        audio_format = extension if extension in MINIMAX_AUDIO_FORMATS else 'mp3'
+        voice_setting = {
+            'voice_id': voice,
+            'speed': max(0.5, min(2.0, speech_rate)),
+            'vol': max(0.1, min(10.0, volume / 50.0)),
+        }
+        client = MiniMaxTTSClient(
+            api_key=self.minimax_api_key,
+            region=self.minimax_region,
+        )
+        return client.synthesize(
+            text,
+            output_path,
+            model=model,
+            voice_setting=voice_setting,
+            audio_setting={'format': audio_format},
+        )
 
     def _voice_meta(self, voice_id: str) -> dict:
         """Return registry metadata for a voice_id (matched via model_id field)."""

--- a/tests/test_minimax_tts.py
+++ b/tests/test_minimax_tts.py
@@ -1,0 +1,170 @@
+from pathlib import Path
+
+import pytest
+
+from src.audio.minimax_tts import (
+    MINIMAX_AUDIO_FORMATS,
+    MINIMAX_TTS_ENDPOINTS,
+    MINIMAX_TTS_MODELS,
+    MiniMaxTTSClient,
+)
+from src.audio.tts import TTSProcessor
+
+
+class _FakeResponse:
+    def __init__(self, payload=None, content=b""):
+        self._payload = payload or {}
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_minimax_catalog_and_regional_endpoints():
+    assert MINIMAX_TTS_ENDPOINTS == {
+        "global": "https://api.minimax.io/v1/t2a_v2",
+        "cn": "https://api.minimaxi.com/v1/t2a_v2",
+    }
+    assert MINIMAX_TTS_MODELS == (
+        "speech-2.8-hd",
+        "speech-2.8-turbo",
+        "speech-2.6-hd",
+        "speech-2.6-turbo",
+        "speech-02-hd",
+        "speech-02-turbo",
+        "speech-01-hd",
+        "speech-01-turbo",
+    )
+    assert MINIMAX_AUDIO_FORMATS == ("mp3", "wav", "flac", "pcm")
+    assert MiniMaxTTSClient(api_key="test", region="cn").endpoint == (
+        "https://api.minimaxi.com/v1/t2a_v2"
+    )
+
+
+def test_minimax_synthesize_sends_supported_fields_and_decodes_hex(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured.update(url=url, headers=headers, body=json, timeout=timeout)
+        return _FakeResponse(
+            {
+                "data": {"audio": b"audio".hex(), "status": 2},
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+                "trace_id": "trace-123",
+            }
+        )
+
+    monkeypatch.setattr("src.audio.minimax_tts.requests.post", fake_post)
+    output = tmp_path / "speech.flac"
+    result = MiniMaxTTSClient(api_key="secret", timeout=15).synthesize(
+        "Hello",
+        str(output),
+        model="speech-2.8-turbo",
+        language_boost="English",
+        output_format="hex",
+        voice_setting={"voice_id": "voice-1", "speed": 1.1},
+        pronunciation_dict={"tone": ["LumenX/Lumen X"]},
+        audio_setting={"format": "flac", "sample_rate": 32000},
+        voice_modify={"pitch": 1},
+        subtitle_enable=True,
+    )
+
+    assert result == (str(output), 0.0, "trace-123")
+    assert output.read_bytes() == b"audio"
+    assert captured["url"] == MINIMAX_TTS_ENDPOINTS["global"]
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert captured["timeout"] == 15
+    assert captured["body"] == {
+        "model": "speech-2.8-turbo",
+        "text": "Hello",
+        "stream": False,
+        "language_boost": "English",
+        "output_format": "hex",
+        "voice_setting": {"voice_id": "voice-1", "speed": 1.1},
+        "pronunciation_dict": {"tone": ["LumenX/Lumen X"]},
+        "audio_setting": {"format": "flac", "sample_rate": 32000},
+        "voice_modify": {"pitch": 1},
+        "subtitle_enable": True,
+    }
+
+
+def test_minimax_synthesize_downloads_url_response(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.audio.minimax_tts.requests.post",
+        lambda *args, **kwargs: _FakeResponse(
+            {
+                "data": {"audio": "https://example.com/audio.wav", "status": 2},
+                "base_resp": {"status_code": 0},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "src.audio.minimax_tts.requests.get",
+        lambda *args, **kwargs: _FakeResponse(content=b"wave"),
+    )
+
+    output = tmp_path / "speech.wav"
+    MiniMaxTTSClient(api_key="test").synthesize(
+        "Hello",
+        str(output),
+        output_format="url",
+        audio_setting={"format": "wav"},
+    )
+    assert output.read_bytes() == b"wave"
+
+
+def test_minimax_api_error_does_not_write_output(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.audio.minimax_tts.requests.post",
+        lambda *args, **kwargs: _FakeResponse(
+            {
+                "data": {"status": 2},
+                "base_resp": {"status_code": 1004, "status_msg": "invalid request"},
+            }
+        ),
+    )
+    output = tmp_path / "speech.mp3"
+
+    with pytest.raises(RuntimeError, match="invalid request"):
+        MiniMaxTTSClient(api_key="test").synthesize("Hello", str(output))
+    assert not output.exists()
+
+
+def test_tts_processor_dispatches_minimax_family(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeMiniMaxClient:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+
+        def synthesize(self, text, output_path, **kwargs):
+            captured.update(text=text, output_path=output_path, options=kwargs)
+            Path(output_path).write_bytes(b"audio")
+            return output_path, 0.0, "trace-456"
+
+    monkeypatch.setattr("src.audio.minimax_tts.MiniMaxTTSClient", FakeMiniMaxClient)
+    processor = TTSProcessor(
+        minimax_api_key="test-key",
+        minimax_region="cn",
+    )
+    output = tmp_path / "speech.wav"
+    result = processor.synthesize(
+        "Hello",
+        str(output),
+        voice="voice-1",
+        speech_rate=1.25,
+        volume=75,
+        model_override="speech-2.8-hd",
+        family_override="minimax",
+    )
+
+    assert result == (str(output), 0.0, "trace-456")
+    assert captured["client"] == {"api_key": "test-key", "region": "cn"}
+    assert captured["options"] == {
+        "model": "speech-2.8-hd",
+        "voice_setting": {"voice_id": "voice-1", "speed": 1.25, "vol": 1.5},
+        "audio_setting": {"format": "wav"},
+    }


### PR DESCRIPTION
Reason: Add MiniMax T2A support to the executable speech pipeline.

Changes:
- Add the Global and China HTTP endpoints, the supported speech model catalog, and audio format validation.
- Forward the supported request fields and parse both hex-encoded and URL audio responses.
- Route the MiniMax family through the existing speech processor and document its environment variables.
- Cover endpoint selection, payload construction, response parsing, errors, and processor dispatch with mocked tests.

Checks:
- `.venv/bin/pytest -q tests/test_minimax_tts.py` (5 passed)
- `uvx black --check src/audio/minimax_tts.py tests/test_minimax_tts.py`
- `uvx ruff check src/audio/minimax_tts.py tests/test_minimax_tts.py`
- `.venv/bin/python -m compileall -q src/audio/minimax_tts.py src/audio/tts.py tests/test_minimax_tts.py`
