### PR TITLE
fix(playground): validate uploaded media

### DIFF
--- a/frontend/src/components/modules/playground/MediaInput.tsx
+++ b/frontend/src/components/modules/playground/MediaInput.tsx
@@ -193,7 +193,7 @@ export default function MediaInput() {
     config = {
       ...config,
       labelKey: 'media.labelRefMaterialAV',
-      accept: 'image/*,video/*,audio/*',
+      accept: 'image/*,video/*',
       hintKey: 'r2vSeedance',
     };
   }
@@ -219,7 +219,7 @@ export default function MediaInput() {
     setUploading(true);
     try {
       const results = await Promise.all(
-        toUpload.map((file) => playgroundApi.uploadMedia(file))
+        toUpload.map((file) => playgroundApi.uploadMedia(file, mode))
       );
       const newPaths = results.map((r) => r.path);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1671,9 +1671,10 @@ export const playgroundApi = {
     axios.delete(API_URL + "/playground/templates/" + id).then(r => r.data),
 
   // Upload media file for playground input (returns file path)
-  uploadMedia: (file: File) => {
+  uploadMedia: (file: File, mode: "t2i" | "i2i" | "t2v" | "i2v" | "r2v" | "v2v") => {
     const formData = new FormData();
     formData.append("file", file);
+    formData.append("mode", mode);
     return axios.post<{ path: string }>(API_URL + "/playground/upload", formData, {
       headers: { "Content-Type": "multipart/form-data" },
     }).then(r => r.data);

--- a/src/apps/playground/api.py
+++ b/src/apps/playground/api.py
@@ -3,9 +3,9 @@
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Literal, Optional
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, UploadFile, File
+from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, UploadFile
 
 from .models import (
     CreateTemplateRequest,
@@ -163,17 +163,98 @@ router.add_api_route("/templates/{template_id}", delete_template, methods=["DELE
 # ---------------------------------------------------------------------------
 
 UPLOAD_DIR = os.path.join("output", "playground", "uploads")
+MAX_UPLOAD_BYTES = 100 * 1024 * 1024
+UPLOAD_CHUNK_BYTES = 1024 * 1024
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+_VIDEO_EXTENSIONS = {".mp4", ".mov", ".webm", ".avi", ".mkv"}
+_ALLOWED_EXTENSIONS = _IMAGE_EXTENSIONS | _VIDEO_EXTENSIONS
+_MODE_MEDIA_KINDS: dict[str, set[str]] = {
+    "t2i": {"image"},
+    "i2i": {"image"},
+    "i2v": {"image"},
+    "r2v": {"image", "video"},
+    "v2v": {"video"},
+}
 
 
-async def upload_media(file: UploadFile = File(...)):
-    """Upload a media file for use as playground input (reference image, first frame, etc.)."""
+def _media_kind_from_signature(header: bytes) -> Optional[Literal["image", "video"]]:
+    """Identify supported media from trusted binary signatures, not client MIME."""
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "image"
+    if header.startswith((b"GIF87a", b"GIF89a")):
+        return "image"
+    if header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return "image"
+    if len(header) >= 12 and header[4:8] == b"ftyp":
+        return "video"
+    if header.startswith(b"\x1a\x45\xdf\xa3"):
+        return "video"
+    if header.startswith(b"RIFF") and header[8:12] == b"AVI ":
+        return "video"
+    return None
+
+
+def _validate_upload_name(filename: Optional[str]) -> str:
+    ext = os.path.splitext(filename or "")[1].lower()
+    if ext not in _ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported file extension. Upload PNG, JPEG, GIF, WebP, MP4, MOV, WebM, AVI, or MKV.",
+        )
+    return ext
+
+
+def _validate_upload_kind(mode: str, extension: str, header: bytes) -> None:
+    if mode not in _MODE_MEDIA_KINDS:
+        raise HTTPException(status_code=400, detail="This generation mode does not accept uploaded media.")
+
+    kind = _media_kind_from_signature(header)
+    if kind is None:
+        raise HTTPException(status_code=400, detail="File content is not a supported image or video format.")
+
+    extension_kind = "image" if extension in _IMAGE_EXTENSIONS else "video"
+    if kind != extension_kind:
+        raise HTTPException(status_code=400, detail="File extension does not match the uploaded file content.")
+    if kind not in _MODE_MEDIA_KINDS[mode]:
+        raise HTTPException(status_code=400, detail=f"Mode '{mode}' does not accept {kind} uploads.")
+
+
+async def upload_media(file: UploadFile = File(...), mode: str = Form(...)):
+    """Upload a validated image/video source for the selected Playground mode.
+
+    The client-supplied MIME type is intentionally ignored: extension allow-lists
+    and binary signatures determine whether the file is accepted.
+    """
+    extension = _validate_upload_name(file.filename)
+    initial_chunk = await file.read(UPLOAD_CHUNK_BYTES)
+    if len(initial_chunk) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="File exceeds the 100 MiB upload limit.")
+    _validate_upload_kind(mode, extension, initial_chunk)
+
     os.makedirs(UPLOAD_DIR, exist_ok=True)
-    ext = os.path.splitext(file.filename or "file")[1] or ".bin"
-    filename = f"{uuid.uuid4()}{ext}"
+    filename = f"{uuid.uuid4()}{extension}"
     dest = os.path.join(UPLOAD_DIR, filename)
-    contents = await file.read()
-    with open(dest, "wb") as f:
-        f.write(contents)
+    written = 0
+
+    try:
+        with open(dest, "wb") as output:
+            output.write(initial_chunk)
+            written += len(initial_chunk)
+            while chunk := await file.read(UPLOAD_CHUNK_BYTES):
+                written += len(chunk)
+                if written > MAX_UPLOAD_BYTES:
+                    raise HTTPException(status_code=413, detail="File exceeds the 100 MiB upload limit.")
+                output.write(chunk)
+    except Exception:
+        if os.path.exists(dest):
+            os.remove(dest)
+        raise
+    finally:
+        await file.close()
+
     return {"path": dest}
 
 

--- a/tests/test_playground_upload.py
+++ b/tests/test_playground_upload.py
@@ -1,0 +1,84 @@
+"""Regression coverage for Playground media upload validation."""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.apps.playground import api as playground_api
+
+
+GIF_BYTES = b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\x00\x00\x00\x00,"
+MP4_BYTES = b"\x00\x00\x00\x18ftypisom\x00\x00\x02\x00isomiso2avc1mp41"
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(playground_api, "UPLOAD_DIR", str(tmp_path / "uploads"))
+    app = FastAPI()
+    app.include_router(playground_api.router, prefix="/playground")
+    return TestClient(app)
+
+
+def upload(client: TestClient, filename: str, content: bytes, mode: str, content_type: str):
+    return client.post(
+        "/playground/upload",
+        data={"mode": mode},
+        files={"file": (filename, content, content_type)},
+    )
+
+
+def test_accepts_image_for_image_mode_without_trusting_mime(client: TestClient):
+    response = upload(client, "reference.gif", GIF_BYTES, "i2v", "video/mp4")
+
+    assert response.status_code == 200
+    path = Path(response.json()["path"])
+    assert path.suffix == ".gif"
+    assert path.read_bytes() == GIF_BYTES
+
+
+def test_accepts_video_for_r2v(client: TestClient):
+    response = upload(client, "reference.mp4", MP4_BYTES, "r2v", "image/png")
+
+    assert response.status_code == 200
+    assert Path(response.json()["path"]).suffix == ".mp4"
+
+
+def test_rejects_extension_outside_allow_list(client: TestClient):
+    response = upload(client, "payload.svg", b"<svg></svg>", "i2i", "image/svg+xml")
+
+    assert response.status_code == 400
+    assert "Unsupported file extension" in response.json()["detail"]
+
+
+def test_rejects_extension_that_does_not_match_file_content(client: TestClient):
+    response = upload(client, "payload.png", MP4_BYTES, "i2i", "image/png")
+
+    assert response.status_code == 400
+    assert "does not match" in response.json()["detail"]
+
+
+def test_rejects_media_kind_not_supported_by_mode(client: TestClient):
+    response = upload(client, "clip.mp4", MP4_BYTES, "i2v", "video/mp4")
+
+    assert response.status_code == 400
+    assert "does not accept video" in response.json()["detail"]
+
+
+def test_rejects_upload_for_text_to_video_mode(client: TestClient):
+    response = upload(client, "clip.mp4", MP4_BYTES, "t2v", "video/mp4")
+
+    assert response.status_code == 400
+    assert "does not accept uploaded media" in response.json()["detail"]
+
+
+def test_rejects_oversized_upload_and_removes_partial_file(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setattr(playground_api, "MAX_UPLOAD_BYTES", len(GIF_BYTES) + 1)
+    response = upload(client, "large.gif", GIF_BYTES + b"overflow", "i2i", "image/gif")
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "File exceeds the 100 MiB upload limit."
+    assert list((tmp_path / "uploads").glob("*")) == []


### PR DESCRIPTION
## 改动说明

本 PR 为 Playground 上传接口补充服务端媒体校验。

- 按生成模式限制上传媒体：
  - `i2i` / `i2v`：仅允许图片
  - `r2v`：允许图片或视频
  - `v2v`：仅允许视频
  - `t2v`：不允许上传媒体
- 服务端仅接受白名单中的文件扩展名。
- 限制单个文件最大为 100 MiB。
- 根据文件内容特征校验图片/视频类型，不信任客户端传入的 MIME Type。
- 对无效文件、类型不匹配或模式不兼容的上传返回明确的 `400 Bad Request`。
- 对超过大小限制的文件返回明确的 `413 Payload Too Large`。
- 前端上传请求会同步提交当前选择的生成模式。

## 问题复现

修改前，客户端可以通过伪造 MIME Type、使用不支持的扩展名，或在不兼容的生成模式中上传媒体文件。

可复现示例：

1. 在 `i2i` 模式上传视频文件。
2. 将非媒体文件重命名为允许的扩展名后上传。
3. 上传有效图片，但伪造客户端 MIME Type。
4. 上传大于 100 MiB 的文件。

修改后，服务端会依据生成模式、扩展名和文件内容进行校验；无效上传会返回明确的 `400` 或 `413` 错误。

## 兼容性与风险

- `POST /playground/upload` 现在要求 multipart 请求携带 `mode` 字段；本 PR 已同步更新项目内前端调用。
- 当前仅接受已加入白名单且可识别文件特征的图片/视频格式；未支持的格式会被主动拒绝。
- 其他直接调用该接口的旧客户端需要补充 `mode` 参数。