### PR TITLE
fix/lockfile-public-registry

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -841,7 +841,7 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@floating-ui/core/-/core-1.8.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/core/-/core-1.8.0.tgz",
       "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
       "dependencies": {
@@ -850,7 +850,7 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.8.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/dom/-/dom-1.8.0.tgz",
       "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
       "dependencies": {
@@ -860,19 +860,19 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.12",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
     "node_modules/@formatjs/fast-memoize": {
       "version": "3.1.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@formatjs/fast-memoize/-/fast-memoize-3.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@formatjs/fast-memoize/-/fast-memoize-3.1.2.tgz",
       "integrity": "sha512-vPnriihkfK0lzoQGaXq+qXH23VsYyansRTkTgo2aTG0k1NjLFyZimFVdfj4C9JkSE5dm7CEngcQ5TTc1yAyBfQ==",
       "license": "MIT"
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
       "version": "3.5.16",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.16.tgz",
+      "resolved": "https://registry.npmmirror.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.16.tgz",
       "integrity": "sha512-kl6b/4D56gjGZi4ZewSmvXbalHwjOUI5ogEHPZqw42goeXTTrL7/yuPzvdrvr0QigDtvaOeb+UeMf62jks43Yg==",
       "license": "MIT",
       "dependencies": {
@@ -881,13 +881,13 @@
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
       "version": "2.1.11",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "resolved": "https://registry.npmmirror.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
       "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "license": "MIT"
     },
     "node_modules/@formatjs/intl-localematcher": {
       "version": "0.8.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@formatjs/intl-localematcher/-/intl-localematcher-0.8.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@formatjs/intl-localematcher/-/intl-localematcher-0.8.3.tgz",
       "integrity": "sha512-pHUjWb9NuhnMs8+PxQdzBtZRFJHlGhrURGAbm6Ltwl82BFajeuiIR3jblSa7ia3r62rXe/0YtVpUG3xWr5bFCA==",
       "license": "MIT",
       "dependencies": {
@@ -934,7 +934,7 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
@@ -952,7 +952,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
@@ -965,7 +965,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
@@ -1067,7 +1067,7 @@
     },
     "node_modules/@next/eslint-plugin-next/node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
@@ -1077,7 +1077,7 @@
     },
     "node_modules/@next/eslint-plugin-next/node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/glob/-/glob-10.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
@@ -1099,14 +1099,14 @@
     },
     "node_modules/@next/eslint-plugin-next/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/lru-cache/-/lru-cache-10.4.3.tgz",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@next/eslint-plugin-next/node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://registry.anpm.alibaba-inc.com/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
@@ -1122,7 +1122,7 @@
     },
     "node_modules/@next/eslint-plugin-next/node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/path-scurry/-/path-scurry-1.11.1.tgz",
+      "resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -1331,7 +1331,7 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -1366,7 +1366,7 @@
     },
     "node_modules/@parcel/watcher-android-arm64": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
       "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
       "cpu": [
         "arm64"
@@ -1386,7 +1386,7 @@
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
       "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
       "cpu": [
         "arm64"
@@ -1406,7 +1406,7 @@
     },
     "node_modules/@parcel/watcher-darwin-x64": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
       "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
       "cpu": [
         "x64"
@@ -1426,7 +1426,7 @@
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
       "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
       "cpu": [
         "x64"
@@ -1446,7 +1446,7 @@
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
       "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
       "cpu": [
         "arm"
@@ -1466,7 +1466,7 @@
     },
     "node_modules/@parcel/watcher-linux-arm-musl": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
@@ -1486,7 +1486,7 @@
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
       "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
       "cpu": [
         "arm64"
@@ -1506,7 +1506,7 @@
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
@@ -1526,7 +1526,7 @@
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
       "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
       "cpu": [
         "x64"
@@ -1546,7 +1546,7 @@
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
@@ -1566,7 +1566,7 @@
     },
     "node_modules/@parcel/watcher-win32-arm64": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
       "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
       "cpu": [
         "arm64"
@@ -1586,7 +1586,7 @@
     },
     "node_modules/@parcel/watcher-win32-ia32": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
       "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
       "cpu": [
         "ia32"
@@ -1606,7 +1606,7 @@
     },
     "node_modules/@parcel/watcher-win32-x64": {
       "version": "2.5.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
       "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
       "cpu": [
         "x64"
@@ -1626,7 +1626,7 @@
     },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/picomatch/-/picomatch-4.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
@@ -1638,7 +1638,7 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "license": "MIT",
@@ -2221,13 +2221,13 @@
     },
     "node_modules/@schummar/icu-type-parser": {
       "version": "1.21.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "resolved": "https://registry.npmmirror.com/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
       "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
       "license": "MIT"
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz",
       "integrity": "sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA==",
       "cpu": [
         "arm64"
@@ -2243,7 +2243,7 @@
     },
     "node_modules/@swc/core-darwin-x64": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-darwin-x64/-/core-darwin-x64-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-darwin-x64/-/core-darwin-x64-1.15.30.tgz",
       "integrity": "sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg==",
       "cpu": [
         "x64"
@@ -2259,7 +2259,7 @@
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.30.tgz",
       "integrity": "sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g==",
       "cpu": [
         "arm"
@@ -2275,7 +2275,7 @@
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.30.tgz",
       "integrity": "sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg==",
       "cpu": [
         "arm64"
@@ -2291,7 +2291,7 @@
     },
     "node_modules/@swc/core-linux-arm64-musl": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.30.tgz",
       "integrity": "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==",
       "cpu": [
         "arm64"
@@ -2307,7 +2307,7 @@
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.30.tgz",
       "integrity": "sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g==",
       "cpu": [
         "ppc64"
@@ -2323,7 +2323,7 @@
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.30.tgz",
       "integrity": "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==",
       "cpu": [
         "s390x"
@@ -2339,7 +2339,7 @@
     },
     "node_modules/@swc/core-linux-x64-gnu": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.30.tgz",
       "integrity": "sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA==",
       "cpu": [
         "x64"
@@ -2355,7 +2355,7 @@
     },
     "node_modules/@swc/core-linux-x64-musl": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.30.tgz",
       "integrity": "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==",
       "cpu": [
         "x64"
@@ -2371,7 +2371,7 @@
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.30.tgz",
       "integrity": "sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q==",
       "cpu": [
         "arm64"
@@ -2387,7 +2387,7 @@
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.30.tgz",
       "integrity": "sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g==",
       "cpu": [
         "ia32"
@@ -2403,7 +2403,7 @@
     },
     "node_modules/@swc/core-win32-x64-msvc": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.30.tgz",
       "integrity": "sha512-4iObHPR+Q4oDY110EF5SF5eIaaVJNpMdG9C0q3Q92BsJ5y467uHz7sYQhP60WYlLFsLQ1el2YrIPUItUAQGOKg==",
       "cpu": [
         "x64"
@@ -2435,7 +2435,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.26",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/types/-/types-0.1.26.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/types/-/types-0.1.26.tgz",
       "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2444,7 +2444,7 @@
     },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tauri-apps/api/-/api-2.11.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/api/-/api-2.11.1.tgz",
       "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
@@ -2541,7 +2541,7 @@
     },
     "node_modules/@tiptap/core": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/core/-/core-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/core/-/core-3.29.2.tgz",
       "integrity": "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==",
       "license": "MIT",
       "funding": {
@@ -2554,7 +2554,7 @@
     },
     "node_modules/@tiptap/extension-blockquote": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-blockquote/-/extension-blockquote-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-blockquote/-/extension-blockquote-3.29.2.tgz",
       "integrity": "sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==",
       "license": "MIT",
       "funding": {
@@ -2568,7 +2568,7 @@
     },
     "node_modules/@tiptap/extension-bold": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-bold/-/extension-bold-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bold/-/extension-bold-3.29.2.tgz",
       "integrity": "sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==",
       "license": "MIT",
       "funding": {
@@ -2581,7 +2581,7 @@
     },
     "node_modules/@tiptap/extension-bubble-menu": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.29.2.tgz",
       "integrity": "sha512-kzcWarcpr031rZu+R3Hzut5uxb3Qj/xxMDEYZIQ3uiq1yb5vEMXj8/SIyWautk6Nu8Rr1leV3rGdR4NzhzyFAA==",
       "license": "MIT",
       "optional": true,
@@ -2599,7 +2599,7 @@
     },
     "node_modules/@tiptap/extension-bullet-list": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-bullet-list/-/extension-bullet-list-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bullet-list/-/extension-bullet-list-3.29.2.tgz",
       "integrity": "sha512-3bWcCUPbCHv0XttlMdnAtXLNYWx2pblByMgxmGsaP9FU0QnslGXty6A6gHCqI33ygRg1vrA6U5Wtpwbi5aKu5g==",
       "license": "MIT",
       "funding": {
@@ -2612,7 +2612,7 @@
     },
     "node_modules/@tiptap/extension-character-count": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-character-count/-/extension-character-count-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-character-count/-/extension-character-count-3.29.2.tgz",
       "integrity": "sha512-tEORzLUIjPQJYYj1wnO5d3XfYhcqJGRBJCQ6tvr572m9ApDRsnEfrQmNUGG4Hnqpjebrn2oSk+oX54UuRT1GUw==",
       "license": "MIT",
       "funding": {
@@ -2625,7 +2625,7 @@
     },
     "node_modules/@tiptap/extension-code": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-code/-/extension-code-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code/-/extension-code-3.29.2.tgz",
       "integrity": "sha512-c6W5UGuB7WNLpYocsgRzpO2OOTI4QjaI9jjHRMuty9z+s9DtaYM/HrRLNwVh6MopkHb+i/89Wkv8gCS34fftig==",
       "license": "MIT",
       "funding": {
@@ -2638,7 +2638,7 @@
     },
     "node_modules/@tiptap/extension-code-block": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-code-block/-/extension-code-block-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code-block/-/extension-code-block-3.29.2.tgz",
       "integrity": "sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==",
       "license": "MIT",
       "funding": {
@@ -2652,7 +2652,7 @@
     },
     "node_modules/@tiptap/extension-document": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-document/-/extension-document-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-document/-/extension-document-3.29.2.tgz",
       "integrity": "sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==",
       "license": "MIT",
       "funding": {
@@ -2665,7 +2665,7 @@
     },
     "node_modules/@tiptap/extension-dropcursor": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-dropcursor/-/extension-dropcursor-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-dropcursor/-/extension-dropcursor-3.29.2.tgz",
       "integrity": "sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==",
       "license": "MIT",
       "funding": {
@@ -2678,7 +2678,7 @@
     },
     "node_modules/@tiptap/extension-floating-menu": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-floating-menu/-/extension-floating-menu-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-floating-menu/-/extension-floating-menu-3.29.2.tgz",
       "integrity": "sha512-CBTq4Xs5aGWr65uFCIkKBms796OhmirWf/ax//iJ4fl9IfwqjwFuc2vQs9PmuwpKn9ctDHo2sMTtvyeCvIt5LQ==",
       "license": "MIT",
       "optional": true,
@@ -2694,7 +2694,7 @@
     },
     "node_modules/@tiptap/extension-gapcursor": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-gapcursor/-/extension-gapcursor-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-gapcursor/-/extension-gapcursor-3.29.2.tgz",
       "integrity": "sha512-8Q39UR4/Tit759IeW9xZIe3NMwN11GsuA3FLheDyyGn7RrW02HD3HhUDlazE54Ki4HoosjFmChPlN4Ik2ubdRQ==",
       "license": "MIT",
       "funding": {
@@ -2707,7 +2707,7 @@
     },
     "node_modules/@tiptap/extension-hard-break": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-hard-break/-/extension-hard-break-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-hard-break/-/extension-hard-break-3.29.2.tgz",
       "integrity": "sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==",
       "license": "MIT",
       "funding": {
@@ -2720,7 +2720,7 @@
     },
     "node_modules/@tiptap/extension-heading": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-heading/-/extension-heading-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-heading/-/extension-heading-3.29.2.tgz",
       "integrity": "sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==",
       "license": "MIT",
       "funding": {
@@ -2733,7 +2733,7 @@
     },
     "node_modules/@tiptap/extension-history": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-history/-/extension-history-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-history/-/extension-history-3.29.2.tgz",
       "integrity": "sha512-AMpvoJxz/gqTMAiUo2LOujR44FoICe9ADaSTJMMV+mc+GxAw3YF3Q6frxIKRZkMGMHYDnHLFei7J2fLvCa4ecA==",
       "license": "MIT",
       "funding": {
@@ -2746,7 +2746,7 @@
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.29.2.tgz",
       "integrity": "sha512-8/ZPzbB9X85Mc9/7xVLZupQKBr2UVcQTGr512xtqMW+XkCQRHCph46tRo828YE13IMWI5fWn/FaNCqXG9cULSw==",
       "license": "MIT",
       "funding": {
@@ -2760,7 +2760,7 @@
     },
     "node_modules/@tiptap/extension-italic": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-italic/-/extension-italic-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-italic/-/extension-italic-3.29.2.tgz",
       "integrity": "sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==",
       "license": "MIT",
       "funding": {
@@ -2773,7 +2773,7 @@
     },
     "node_modules/@tiptap/extension-link": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-link/-/extension-link-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-link/-/extension-link-3.29.2.tgz",
       "integrity": "sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==",
       "license": "MIT",
       "dependencies": {
@@ -2790,7 +2790,7 @@
     },
     "node_modules/@tiptap/extension-list": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-list/-/extension-list-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list/-/extension-list-3.29.2.tgz",
       "integrity": "sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==",
       "license": "MIT",
       "funding": {
@@ -2804,7 +2804,7 @@
     },
     "node_modules/@tiptap/extension-list-item": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-list-item/-/extension-list-item-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list-item/-/extension-list-item-3.29.2.tgz",
       "integrity": "sha512-s8vBVHHFT0Qpu7CzAZ7S1kYmSiVaDvUNvMNcZUWnxj6VPfiwmx0eXd9FsjePrRCMoM5tFmPnhFTHDxY3D/eZeQ==",
       "license": "MIT",
       "funding": {
@@ -2817,7 +2817,7 @@
     },
     "node_modules/@tiptap/extension-list-keymap": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-list-keymap/-/extension-list-keymap-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list-keymap/-/extension-list-keymap-3.29.2.tgz",
       "integrity": "sha512-R+3k8OLnxdCH7Xy9ieOwUt5m2Je74u8mikothGmsYVO2Zyq48fIbmZ+X6RBPCu7DBOI2FIUhHEFbKQeDWvDNmA==",
       "license": "MIT",
       "funding": {
@@ -2830,7 +2830,7 @@
     },
     "node_modules/@tiptap/extension-mention": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-mention/-/extension-mention-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-mention/-/extension-mention-3.29.2.tgz",
       "integrity": "sha512-WF8ugDa2IRbgyRW+PffPYg8ZI+Qp9azvIsNoyuf+VSg5Vp7ze2TuJXUTObSckyiN5Ann8bDNM9Hbu3TdoI0DFQ==",
       "license": "MIT",
       "funding": {
@@ -2845,7 +2845,7 @@
     },
     "node_modules/@tiptap/extension-ordered-list": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-ordered-list/-/extension-ordered-list-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-ordered-list/-/extension-ordered-list-3.29.2.tgz",
       "integrity": "sha512-ndCunC+UsYOpkOtL7vGnDz21UNa45WUlcO9wMT1fbuYow2QnRhsuMlCWENXI52YPPARWuQ0RDgN7q6TaxPERBg==",
       "license": "MIT",
       "funding": {
@@ -2858,7 +2858,7 @@
     },
     "node_modules/@tiptap/extension-paragraph": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-paragraph/-/extension-paragraph-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-paragraph/-/extension-paragraph-3.29.2.tgz",
       "integrity": "sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==",
       "license": "MIT",
       "funding": {
@@ -2871,7 +2871,7 @@
     },
     "node_modules/@tiptap/extension-placeholder": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-placeholder/-/extension-placeholder-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-placeholder/-/extension-placeholder-3.29.2.tgz",
       "integrity": "sha512-/BlpPIq2JZk6zLaeYVOXazi6dmd0iRriTymNEnFn1doManN1y5HED9LsMeb/AhNhauL5AgmcHgpvAjbsN9k4SA==",
       "license": "MIT",
       "funding": {
@@ -2884,7 +2884,7 @@
     },
     "node_modules/@tiptap/extension-strike": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-strike/-/extension-strike-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-strike/-/extension-strike-3.29.2.tgz",
       "integrity": "sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==",
       "license": "MIT",
       "funding": {
@@ -2897,7 +2897,7 @@
     },
     "node_modules/@tiptap/extension-text": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-text/-/extension-text-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text/-/extension-text-3.29.2.tgz",
       "integrity": "sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==",
       "license": "MIT",
       "funding": {
@@ -2910,7 +2910,7 @@
     },
     "node_modules/@tiptap/extension-underline": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extension-underline/-/extension-underline-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-underline/-/extension-underline-3.29.2.tgz",
       "integrity": "sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==",
       "license": "MIT",
       "funding": {
@@ -2923,7 +2923,7 @@
     },
     "node_modules/@tiptap/extensions": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/extensions/-/extensions-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extensions/-/extensions-3.29.2.tgz",
       "integrity": "sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==",
       "license": "MIT",
       "funding": {
@@ -2937,7 +2937,7 @@
     },
     "node_modules/@tiptap/pm": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/pm/-/pm-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/pm/-/pm-3.29.2.tgz",
       "integrity": "sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==",
       "license": "MIT",
       "dependencies": {
@@ -2962,7 +2962,7 @@
     },
     "node_modules/@tiptap/react": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/react/-/react-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/react/-/react-3.29.2.tgz",
       "integrity": "sha512-ZMKgteYmZXnq7C22U9fbCTC6jAF8XlQM5n2K2FLWCdYAlP4FNV3XeQ9hY2a13KSQ0Q3yltWXZlcWBpt5ClxScg==",
       "license": "MIT",
       "dependencies": {
@@ -2989,7 +2989,7 @@
     },
     "node_modules/@tiptap/starter-kit": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/starter-kit/-/starter-kit-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/starter-kit/-/starter-kit-3.29.2.tgz",
       "integrity": "sha512-oTu0tysiqk4zgjEtxRHjAQgxUKaAevZwueOWwSWubHdokqp7SpcbE5n9USJv89HKuTUDm3GjnQH6q8HNn/2DsA==",
       "license": "MIT",
       "dependencies": {
@@ -3025,7 +3025,7 @@
     },
     "node_modules/@tiptap/suggestion": {
       "version": "3.29.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@tiptap/suggestion/-/suggestion-3.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@tiptap/suggestion/-/suggestion-3.29.2.tgz",
       "integrity": "sha512-ZEhRm0gnRCwCScR9IrnIBhm9sr6U8vpR9oeznYk3hiedZ48zsgohqvgoIYpWcwYWrT2Pb0NrfhCT8IuSzdJHzQ==",
       "license": "MIT",
       "funding": {
@@ -3065,7 +3065,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@types/chai/-/chai-5.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
@@ -3076,7 +3076,7 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
@@ -3174,7 +3174,7 @@
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
@@ -3186,14 +3186,14 @@
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@types/ws/-/ws-8.18.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
@@ -3392,7 +3392,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
@@ -3767,7 +3767,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@vitest/expect/-/expect-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-3.2.7.tgz",
       "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
@@ -3784,7 +3784,7 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "3.2.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-3.2.7.tgz",
       "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
@@ -3811,7 +3811,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
       "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
@@ -3824,7 +3824,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "3.2.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@vitest/runner/-/runner-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-3.2.7.tgz",
       "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
@@ -3839,7 +3839,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "3.2.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-3.2.7.tgz",
       "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
@@ -3854,7 +3854,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "3.2.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@vitest/spy/-/spy-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-3.2.7.tgz",
       "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
@@ -3867,7 +3867,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "3.2.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@vitest/utils/-/utils-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-3.2.7.tgz",
       "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
@@ -4169,7 +4169,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/assertion-error/-/assertion-error-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
@@ -4196,7 +4196,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
@@ -4228,7 +4228,7 @@
     },
     "node_modules/axios": {
       "version": "1.19.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/axios/-/axios-1.19.0.tgz",
+      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.19.0.tgz",
       "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
@@ -4240,7 +4240,7 @@
     },
     "node_modules/axios/node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/agent-base/-/agent-base-6.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "dependencies": {
@@ -4252,7 +4252,7 @@
     },
     "node_modules/axios/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "dependencies": {
@@ -4333,7 +4333,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.18",
-      "resolved": "https://registry.anpm.alibaba-inc.com/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
@@ -4500,7 +4500,7 @@
     },
     "node_modules/chai": {
       "version": "5.3.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/chai/-/chai-5.3.3.tgz",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-5.3.3.tgz",
       "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
@@ -4534,7 +4534,7 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/check-error/-/check-error-2.1.3.tgz",
+      "resolved": "https://registry.npmmirror.com/check-error/-/check-error-2.1.3.tgz",
       "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
@@ -4617,7 +4617,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.anpm.alibaba-inc.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "dependencies": {
@@ -4862,7 +4862,7 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/deep-eql/-/deep-eql-5.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
@@ -4915,7 +4915,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "engines": {
@@ -4944,7 +4944,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "engines": {
@@ -5008,7 +5008,7 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
@@ -5708,7 +5708,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
@@ -5745,7 +5745,7 @@
     },
     "node_modules/fast-equals": {
       "version": "5.4.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/fast-equals/-/fast-equals-5.4.1.tgz",
+      "resolved": "https://registry.npmmirror.com/fast-equals/-/fast-equals-5.4.1.tgz",
       "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
       "license": "MIT",
       "engines": {
@@ -5872,14 +5872,14 @@
     },
     "node_modules/flatted": {
       "version": "3.4.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/flatted/-/flatted-3.4.4.tgz",
+      "resolved": "https://registry.npmmirror.com/flatted/-/flatted-3.4.4.tgz",
       "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
@@ -5915,7 +5915,7 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/foreground-child/-/foreground-child-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
@@ -5932,7 +5932,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/form-data/-/form-data-4.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
@@ -6185,7 +6185,7 @@
     },
     "node_modules/happy-dom": {
       "version": "20.8.9",
-      "resolved": "https://registry.anpm.alibaba-inc.com/happy-dom/-/happy-dom-20.8.9.tgz",
+      "resolved": "https://registry.npmmirror.com/happy-dom/-/happy-dom-20.8.9.tgz",
       "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
@@ -6203,7 +6203,7 @@
     },
     "node_modules/happy-dom/node_modules/entities": {
       "version": "7.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/entities/-/entities-7.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6216,7 +6216,7 @@
     },
     "node_modules/happy-dom/node_modules/whatwg-mimetype": {
       "version": "3.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "license": "MIT",
@@ -6305,7 +6305,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
@@ -6390,7 +6390,7 @@
     },
     "node_modules/icu-minify": {
       "version": "4.13.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/icu-minify/-/icu-minify-4.13.5.tgz",
+      "resolved": "https://registry.npmmirror.com/icu-minify/-/icu-minify-4.13.5.tgz",
       "integrity": "sha512-sGCVm06cfsk/t9F4s9vYBCCI5k5cf2SuH21uPm6L9uK8i+bWY9NDMSUsYzYsZ4lxohTvGa3oGixtlQvZMMz5fg==",
       "funding": [
         {
@@ -6493,7 +6493,7 @@
     },
     "node_modules/intl-messageformat": {
       "version": "11.2.13",
-      "resolved": "https://registry.anpm.alibaba-inc.com/intl-messageformat/-/intl-messageformat-11.2.13.tgz",
+      "resolved": "https://registry.npmmirror.com/intl-messageformat/-/intl-messageformat-11.2.13.tgz",
       "integrity": "sha512-JaPaE6TIX+TAS5XLhDUh41geLw4QfBHX4s5pW8Km+L9fVC8HzB9yOuhbh4EMR/F1+8C6b9qk4763Cv+LdOG1kg==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6503,7 +6503,7 @@
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/fast-memoize": {
       "version": "3.1.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "resolved": "https://registry.npmmirror.com/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
       "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
       "license": "MIT"
     },
@@ -6692,7 +6692,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
@@ -7007,7 +7007,7 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/jackspeak/-/jackspeak-3.4.3.tgz",
+      "resolved": "https://registry.npmmirror.com/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7039,7 +7039,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/js-yaml/-/js-yaml-4.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
@@ -7225,7 +7225,7 @@
     },
     "node_modules/linkifyjs": {
       "version": "4.3.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "resolved": "https://registry.npmmirror.com/linkifyjs/-/linkifyjs-4.3.3.tgz",
       "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "license": "MIT"
     },
@@ -7266,7 +7266,7 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/loupe/-/loupe-3.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
@@ -7303,7 +7303,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.anpm.alibaba-inc.com/magic-string/-/magic-string-0.30.21.tgz",
+      "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
@@ -7368,7 +7368,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
@@ -7377,7 +7377,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.anpm.alibaba-inc.com/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
@@ -7422,7 +7422,7 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/minipass/-/minipass-7.1.3.tgz",
+      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7465,7 +7465,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
-      "resolved": "https://registry.anpm.alibaba-inc.com/nanoid/-/nanoid-3.3.18.tgz",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.18.tgz",
       "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
@@ -7506,7 +7506,7 @@
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/negotiator/-/negotiator-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
@@ -7565,7 +7565,7 @@
     },
     "node_modules/next-intl": {
       "version": "4.13.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/next-intl/-/next-intl-4.13.5.tgz",
+      "resolved": "https://registry.npmmirror.com/next-intl/-/next-intl-4.13.5.tgz",
       "integrity": "sha512-9tIeZmBgxS0yYw+NN0mOfLxrH/r1l9CF/A4noKCwUfTyGIHZHrUmBnvOhbNmI4TgN7Piraf+BmIDU9pnZzjF7A==",
       "funding": [
         {
@@ -7596,13 +7596,13 @@
     },
     "node_modules/next-intl-swc-plugin-extractor": {
       "version": "4.13.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.5.tgz",
+      "resolved": "https://registry.npmmirror.com/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.5.tgz",
       "integrity": "sha512-Sxdgpp4y12zUYq8XzZoQQSIL9CU1T210l7dLrfVLeIykaRslBJEHNacGTy8CLqJc5uLFsmzukANbEOpa5XgAiQ==",
       "license": "MIT"
     },
     "node_modules/next-intl/node_modules/@swc/core": {
       "version": "1.15.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/core/-/core-1.15.30.tgz",
+      "resolved": "https://registry.npmmirror.com/@swc/core/-/core-1.15.30.tgz",
       "integrity": "sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -7640,20 +7640,9 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
@@ -7819,7 +7808,7 @@
     },
     "node_modules/orderedmap": {
       "version": "2.1.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/orderedmap/-/orderedmap-2.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
@@ -7875,7 +7864,7 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
@@ -7941,7 +7930,7 @@
     },
     "node_modules/pathval": {
       "version": "2.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/pathval/-/pathval-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/pathval/-/pathval-2.0.1.tgz",
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
@@ -7957,7 +7946,7 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -7990,7 +7979,7 @@
     },
     "node_modules/po-parser": {
       "version": "2.1.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/po-parser/-/po-parser-2.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/po-parser/-/po-parser-2.1.1.tgz",
       "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
       "license": "MIT"
     },
@@ -8006,9 +7995,8 @@
     },
     "node_modules/postcss": {
       "version": "8.5.26",
-      "resolved": "https://registry.anpm.alibaba-inc.com/postcss/-/postcss-8.5.26.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.26.tgz",
       "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8244,7 +8232,7 @@
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.4.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
       "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
       "license": "MIT",
       "dependencies": {
@@ -8253,7 +8241,7 @@
     },
     "node_modules/prosemirror-commands": {
       "version": "1.7.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
       "integrity": "sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==",
       "license": "MIT",
       "dependencies": {
@@ -8264,7 +8252,7 @@
     },
     "node_modules/prosemirror-dropcursor": {
       "version": "1.8.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
       "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
       "license": "MIT",
       "dependencies": {
@@ -8275,7 +8263,7 @@
     },
     "node_modules/prosemirror-gapcursor": {
       "version": "1.4.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
       "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
       "license": "MIT",
       "dependencies": {
@@ -8287,7 +8275,7 @@
     },
     "node_modules/prosemirror-history": {
       "version": "1.5.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
       "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
       "license": "MIT",
       "dependencies": {
@@ -8299,7 +8287,7 @@
     },
     "node_modules/prosemirror-inputrules": {
       "version": "1.5.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
       "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
       "license": "MIT",
       "dependencies": {
@@ -8309,7 +8297,7 @@
     },
     "node_modules/prosemirror-keymap": {
       "version": "1.2.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
       "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "license": "MIT",
       "dependencies": {
@@ -8319,7 +8307,7 @@
     },
     "node_modules/prosemirror-model": {
       "version": "1.25.11",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
       "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
       "license": "MIT",
       "dependencies": {
@@ -8328,7 +8316,7 @@
     },
     "node_modules/prosemirror-schema-list": {
       "version": "1.5.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
       "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
       "license": "MIT",
       "dependencies": {
@@ -8339,7 +8327,7 @@
     },
     "node_modules/prosemirror-state": {
       "version": "1.4.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
       "dependencies": {
@@ -8350,7 +8338,7 @@
     },
     "node_modules/prosemirror-tables": {
       "version": "1.8.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
       "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
       "license": "MIT",
       "dependencies": {
@@ -8363,7 +8351,7 @@
     },
     "node_modules/prosemirror-transform": {
       "version": "1.12.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
       "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
       "license": "MIT",
       "dependencies": {
@@ -8372,7 +8360,7 @@
     },
     "node_modules/prosemirror-view": {
       "version": "1.42.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+      "resolved": "https://registry.npmmirror.com/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
       "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
       "license": "MIT",
       "dependencies": {
@@ -8383,7 +8371,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
       "engines": {
@@ -8665,7 +8653,7 @@
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
@@ -8675,7 +8663,7 @@
     },
     "node_modules/rimraf/node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/glob/-/glob-10.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
@@ -8697,14 +8685,14 @@
     },
     "node_modules/rimraf/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/lru-cache/-/lru-cache-10.4.3.tgz",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/rimraf/node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://registry.anpm.alibaba-inc.com/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
@@ -8720,7 +8708,7 @@
     },
     "node_modules/rimraf/node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/path-scurry/-/path-scurry-1.11.1.tgz",
+      "resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -8782,7 +8770,7 @@
     },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "resolved": "https://registry.npmmirror.com/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
@@ -9069,7 +9057,7 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
@@ -9160,7 +9148,7 @@
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/string-width/-/string-width-5.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
@@ -9179,7 +9167,7 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
@@ -9194,14 +9182,14 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
@@ -9214,7 +9202,7 @@
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
@@ -9357,7 +9345,7 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -9406,7 +9394,7 @@
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/strip-literal/-/strip-literal-3.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-literal/-/strip-literal-3.1.0.tgz",
       "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
       "dev": true,
       "license": "MIT",
@@ -9419,7 +9407,7 @@
     },
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/js-tokens/-/js-tokens-9.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
@@ -9688,7 +9676,7 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/picomatch/-/picomatch-4.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
@@ -9711,7 +9699,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
@@ -9721,7 +9709,7 @@
     },
     "node_modules/tinyspy": {
       "version": "4.0.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/tinyspy/-/tinyspy-4.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/tinyspy/-/tinyspy-4.0.4.tgz",
       "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
@@ -10085,7 +10073,7 @@
     },
     "node_modules/use-intl": {
       "version": "4.13.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/use-intl/-/use-intl-4.13.5.tgz",
+      "resolved": "https://registry.npmmirror.com/use-intl/-/use-intl-4.13.5.tgz",
       "integrity": "sha512-oYpi0M6Cd7V0ZAvOPakB3kUCVzpwsVbod47G/xbZV5dvrqFMAw4fcwOS+sKpAjVdNW+CbQUeBk4Vnyzmk/07Bw==",
       "funding": [
         {
@@ -10153,7 +10141,7 @@
     },
     "node_modules/vite": {
       "version": "7.3.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/vite/-/vite-7.3.5.tgz",
+      "resolved": "https://registry.npmmirror.com/vite/-/vite-7.3.5.tgz",
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
@@ -10269,7 +10257,7 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/picomatch/-/picomatch-4.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
@@ -10282,7 +10270,7 @@
     },
     "node_modules/vitest": {
       "version": "3.2.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/vitest/-/vitest-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-3.2.7.tgz",
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
@@ -10355,7 +10343,7 @@
     },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/picomatch/-/picomatch-4.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
@@ -10368,7 +10356,7 @@
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
-      "resolved": "https://registry.anpm.alibaba-inc.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "resolved": "https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
@@ -10577,7 +10565,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
@@ -10596,7 +10584,7 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
@@ -10614,14 +10602,14 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
@@ -10636,7 +10624,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
@@ -10649,7 +10637,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
@@ -10662,7 +10650,7 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
@@ -10678,7 +10666,7 @@
     },
     "node_modules/ws": {
       "version": "8.21.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ws/-/ws-8.21.3.tgz",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
package-lock.json pins all resolved URLs to registry.anpm.alibaba-inc.com (internal registry, unreachable outside Alibaba network). External users get ETIMEDOUT on npm install. Replace with the public mirror registry.npmmirror.com (operated by Alibaba, same packages). Verified: full npm install succeeds from outside the intranet.