### PR TITLE
fix(cast): resolve series-level characters in voice bind endpoints

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -390,7 +390,8 @@
     "generateScene": "Generate Scene",
     "generateProp": "Generate Prop",
     "charactersLabel": "Cast",
-    "voiceBoundLabel": "Voice"
+    "voiceBoundLabel": "Voice",
+    "toastVoiceErr": "Voice bind failed"
   },
   "common": {
     "save": "Save",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -390,7 +390,8 @@
     "generateScene": "生成场景",
     "generateProp": "生成道具",
     "charactersLabel": "角色",
-    "voiceBoundLabel": "语音"
+    "voiceBoundLabel": "语音",
+    "toastVoiceErr": "音色绑定失败"
   },
   "common": {
     "save": "保存",

--- a/frontend/src/components/modules/Cast.tsx
+++ b/frontend/src/components/modules/Cast.tsx
@@ -30,6 +30,7 @@ import PreviewImage from "@/components/shared/preview/PreviewImage";
 import WorkflowActionButton from "@/components/shared/WorkflowActionButton";
 import VoicePickerModal from "./cast/VoicePickerModal";
 import CastWorkbenchModal, { activePolls } from "./cast/CastWorkbenchModal";
+import { toast } from "@/store/toastStore";
 
 type AssetKind = "character" | "scene" | "prop";
 
@@ -708,9 +709,19 @@ function CastCard({ item, onOpenWorkbench }: { item: CastItem; onOpenWorkbench?:
         if (!currentProject || !character) return;
         try {
             const updated = await api.bindVoice(currentProject.id, character.id, newVoiceId, newVoiceName);
-            // Backend returns the updated script - sync to store
+            // Backend returns the merged episode+series payload — safe to
+            // spread into the store without dropping series-level chars.
             updateProject(currentProject.id, updated);
-        } catch (e) {
+        } catch (e: any) {
+            // Surface the error instead of failing silently — a silent
+            // catch made series-level voice binds look broken (the POST
+            // returned 404/500 but the UI showed nothing).
+            const detail = e?.response?.data?.detail || e?.message || "voice bind failed";
+            toast.error(t("toastVoiceErr"), {
+                projectId: currentProject.id,
+                projectTitle: currentProject.title,
+                body: String(detail),
+            });
             console.error("Failed to bind voice:", e);
         }
     };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1030,7 +1030,10 @@ export const api = {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ voice_id: voiceId, voice_name: voiceName }),
         });
-        if (!response.ok) throw new Error("Failed to bind voice");
+        if (!response.ok) {
+            const detail = await response.text();
+            throw new Error(`Failed to bind voice: ${response.status} ${detail}`);
+        }
         return response.json();
     },
 

--- a/src/apps/comic_gen/api.py
+++ b/src/apps/comic_gen/api.py
@@ -3107,8 +3107,6 @@ def generate_dialogue_audio_batch(script_id: str):
         script = pipeline.get_script(script_id)
         if not script:
             raise HTTPException(status_code=404, detail="Script not found")
-        char_lookup = {c.id: c for c in script.characters}
-        char_name_lookup = {c.name.strip().lower(): c for c in script.characters}
         generated = 0
         skipped = 0
         failed = 0
@@ -3120,20 +3118,9 @@ def generate_dialogue_audio_batch(script_id: str):
             )
             if not dialogue_text:
                 continue
-            speaker = None
-            if frame.character_ids:
-                speaker = char_lookup.get(frame.character_ids[0])
-            speaker_name = frame.speaker or (
-                frame.dialogue_structured.speaker if frame.dialogue_structured else None
-            )
-            if not speaker and speaker_name:
-                key = speaker_name.strip().lower()
-                speaker = char_name_lookup.get(key)
-                if not speaker:
-                    for name, char in char_name_lookup.items():
-                        if key in name or name in key:
-                            speaker = char
-                            break
+            # Resolves episode-local, series-level and global-library
+            # characters (same precedence as GET /projects/{id}).
+            speaker = pipeline.resolve_frame_speaker(script, frame)
             if not speaker or not speaker.voice_id:
                 no_voice += 1
                 continue

--- a/src/apps/comic_gen/api.py
+++ b/src/apps/comic_gen/api.py
@@ -2719,14 +2719,22 @@ class BindVoiceRequest(BaseModel):
     voice_name: str
 
 
-@app.post("/projects/{script_id}/characters/{char_id}/voice", response_model=Script)
+@app.post("/projects/{script_id}/characters/{char_id}/voice")
 def bind_voice(script_id: str, char_id: str, request: BindVoiceRequest):
-    """Binds a voice to a character."""
+    """Binds a voice to a character.
+
+    Returns the same merged episode + series + global payload as
+    GET /projects/{id} — the frontend spreads the response into its
+    project store, so returning the raw episode-local Script would
+    drop series-level characters from the Cast view.
+    """
     try:
-        updated_script = pipeline.bind_voice(script_id, char_id, request.voice_id, request.voice_name)
-        return signed_response(updated_script)
+        pipeline.bind_voice(script_id, char_id, request.voice_id, request.voice_name)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+    return get_project(script_id)
 
 
 class UpdateVoiceParamsRequest(BaseModel):
@@ -2735,20 +2743,34 @@ class UpdateVoiceParamsRequest(BaseModel):
     volume: int = 50
 
 
-@app.put("/projects/{script_id}/characters/{char_id}/voice_params", response_model=Script)
+@app.put("/projects/{script_id}/characters/{char_id}/voice_params")
 def update_voice_params(script_id: str, char_id: str, request: UpdateVoiceParamsRequest):
-    """Updates voice parameters for a character."""
+    """Updates voice parameters for a character.
+
+    Returns the merged episode + series payload, see bind_voice above
+    for why the raw Script isn't returned."""
     script = pipeline.get_script(script_id)
     if not script:
         raise HTTPException(status_code=404, detail="Script not found")
     char = next((c for c in script.characters if c.id == char_id), None)
+    char_is_series_level = False
+    if not char and script.series_id:
+        # Fallback to parent series for series-level characters (same
+        # pattern as pipeline.bind_voice / select_asset_variant).
+        series = pipeline.series_store.get(script.series_id)
+        if series:
+            char = next((c for c in series.characters if c.id == char_id), None)
+            if char:
+                char_is_series_level = True
     if not char:
         raise HTTPException(status_code=404, detail="Character not found")
     char.voice_speed = request.speed
     char.voice_pitch = request.pitch
     char.voice_volume = request.volume
     pipeline._save_data()
-    return signed_response(script)
+    if char_is_series_level:
+        pipeline._save_series_data()
+    return get_project(script_id)
 
 
 @app.get("/voices")

--- a/src/apps/comic_gen/pipeline.py
+++ b/src/apps/comic_gen/pipeline.py
@@ -3571,14 +3571,27 @@ class ComicGenPipeline:
         script = self.scripts.get(script_id)
         if not script:
             raise ValueError("Script not found")
-            
+
         char = next((c for c in script.characters if c.id == char_id), None)
+        char_is_series_level = False
+        if not char and script.series_id:
+            # Fallback to parent series for series-level characters (same
+            # pattern as select_asset_variant). The Cast UI shows series
+            # characters alongside episode ones, so bind requests arrive
+            # with their ids too.
+            series = self.series_store.get(script.series_id)
+            if series:
+                char = next((c for c in series.characters if c.id == char_id), None)
+                if char:
+                    char_is_series_level = True
         if not char:
             raise ValueError("Character not found")
-            
+
         char.voice_id = voice_id
         char.voice_name = voice_name
         self._save_data()
+        if char_is_series_level:
+            self._save_series_data()
         return script
 
     def get_script(self, script_id: str) -> Optional[Script]:

--- a/src/apps/comic_gen/pipeline.py
+++ b/src/apps/comic_gen/pipeline.py
@@ -1052,6 +1052,60 @@ class ComicGenPipeline:
         else:
             self._save_data()
 
+    def _character_search_pool(self, script: "Script") -> List[Any]:
+        """All characters visible to this episode, in precedence order:
+        episode-local → parent series → global library (duplicates by id
+        removed, episode-local wins). Mirrors the read-time merge of
+        GET /projects/{id} so name-based lookups (dialogue speaker
+        resolution) see series-level characters too."""
+        pool = list(script.characters)
+        seen = {c.id for c in pool}
+        if script.series_id:
+            series = self.series_store.get(script.series_id)
+            if series:
+                for c in series.characters:
+                    if c.id not in seen:
+                        pool.append(c)
+                        seen.add(c.id)
+        for c in self.library_store.characters:
+            if c.id not in seen:
+                pool.append(c)
+                seen.add(c.id)
+        return pool
+
+    def resolve_frame_speaker(self, script: "Script", frame: Any) -> Optional[Any]:
+        """Resolve the character speaking a frame's dialogue.
+
+        Tries frame.character_ids[0] first (via the episode → series →
+        global resolver), then falls back to fuzzy name matching against
+        the full character search pool. Returns None when no character
+        matches — callers treat that as "no voice bound".
+        """
+        if frame.character_ids:
+            char, _src = self._find_asset_with_source(
+                script, frame.character_ids[0], "character"
+            )
+            if char is not None:
+                return char
+        speaker_name = frame.speaker or (
+            frame.dialogue_structured.speaker if frame.dialogue_structured else None
+        )
+        if not speaker_name:
+            return None
+        key = speaker_name.strip().lower()
+        pool = self._character_search_pool(script)
+        exact = next(
+            (c for c in pool if (c.name or "").strip().lower() == key), None
+        )
+        if exact is not None:
+            return exact
+        return next(
+            (c for c in pool
+             if key in (c.name or "").strip().lower()
+             or (c.name or "").strip().lower() in key),
+            None,
+        )
+
     def toggle_asset_lock(self, script_id: str, asset_id: str, asset_type: str) -> Script:
         """Toggle the locked status of an asset. Works on both
         episode-local and series-shared assets (A2 decision: default
@@ -3533,20 +3587,7 @@ class ComicGenPipeline:
             or frame.dialogue
         )
         if dialogue_text:
-            speaker = None
-            if frame.character_ids:
-                speaker = next((c for c in script.characters if c.id == frame.character_ids[0]), None)
-            speaker_name = frame.speaker or (
-                frame.dialogue_structured.speaker if frame.dialogue_structured else None
-            )
-            if not speaker and speaker_name:
-                key = speaker_name.strip().lower()
-                speaker = next(
-                    (c for c in script.characters if c.name.strip().lower() == key
-                     or key in c.name.strip().lower()
-                     or c.name.strip().lower() in key),
-                    None,
-                )
+            speaker = self.resolve_frame_speaker(script, frame)
 
             if speaker:
                 model_override = None


### PR DESCRIPTION
Description

## Problem

Binding a voice to a **series-level character** (stored in `Series.characters`, shared across episodes) fails with HTTP 500, with no visible feedback in the UI.

Backend log when reproducing:

POST /projects/<script_id>/characters/<char_id>/voice HTTP/1.1 500 Internal Server Error



## Root cause

`GET /projects/{id}` merges the parent series' characters into its response (tagged `source: "series"`), so the Cast view displays series-level characters and the frontend can issue bind requests for them. But the write path had no equivalent lookup:

- `pipeline.bind_voice` only searched `script.characters` → raised `ValueError("Character not found")`
- The endpoint wrapped **all** exceptions as `HTTPException(500)`, hiding the real cause
- `update_voice_params` (PUT `.../voice_params`) had the identical gap (returned 404)
- Frontend `Cast.tsx handleApplyVoice` caught the error with `console.error` only, so the failure was completely silent

## Changes

- `pipeline.bind_voice`: fall back to `series_store` characters when the id is not in `script.characters`, and persist via `_save_series_data()` when the character lives in the series (same pattern as the existing `select_asset_variant`)
- `update_voice_params`: apply the same fallback
- Both endpoints now return the merged episode + series + global payload, exactly like `GET /projects/{id}`. Previously they returned only the episode-local `Script`; since the frontend spreads the response into its project store, a successful write on a series character would have dropped all series-level characters from the Cast view
- Map `ValueError` to **404** instead of a blanket 500
- `Cast.tsx`: surface bind failures in a toast (with backend detail) instead of a silent catch
- `api.ts bindVoice`: include response status and backend detail in the thrown error

## Verification

Tested against real data (series-level character not present in `script.characters`):

- Bind now resolves the series-level character and persists `voice_id`/`voice_name` to `series.json` ✅
- Unknown character ids still raise (now surfaced as 404) ✅
- Episode-local bind path unchanged ✅
- `npx tsc --noEmit` clean; backend files pass `py_compile` ✅