### PR TITLE
fix(video): 修复 wan2.7-r2v / wan2.7-i2v 视频生成失败（Windows 反斜杠媒体引用 + 请求体改用 input.media）

### DIFF
--- a/src/apps/comic_gen/pipeline.py
+++ b/src/apps/comic_gen/pipeline.py
@@ -3374,6 +3374,7 @@ class ComicGenPipeline:
             
             task.video_url = os.path.relpath(output_path, "output")
             task.status = "completed"
+            task.error = None
             
             # Sync with asset if this is an asset video
             if task.asset_id:
@@ -3384,6 +3385,9 @@ class ComicGenPipeline:
             logger.exception("Failed to process video task")
             logger.error(f"Video generation failed: {e}")
             task.status = "failed"
+            # Persist the failure reason so the queue panel / UI can show it;
+            # previously only the log captured it and task.error stayed null.
+            task.error = str(e) or type(e).__name__
             if task.asset_id:
                 self._sync_asset_video_task(script, task)
             

--- a/src/models/wanx.py
+++ b/src/models/wanx.py
@@ -562,12 +562,22 @@ class WanxModel(VideoGenModel):
         if extra_headers:
             headers.update(dict(extra_headers))
         
+        input_payload = {"prompt": prompt}
+        is_wan27 = model_name.startswith("wan2.7-")
+        if is_wan27:
+            # wan2.7 series uses the unified media array:
+            # first_frame image, optionally a driving_audio track
+            # (audio_url drives lip-sync / motion).
+            media_items = [{"type": "first_frame", "url": img_url}]
+            if audio_url:
+                media_items.append({"type": "driving_audio", "url": audio_url})
+            input_payload["media"] = media_items
+        else:
+            input_payload["img_url"] = img_url
+
         payload = {
             "model": model_name,  # Use passed model name (wan2.5-i2v, wan2.6-i2v, or wan2.7-i2v)
-            "input": {
-                "prompt": prompt,
-                "img_url": img_url
-            },
+            "input": input_payload,
             "parameters": {
                 "duration": duration,
                 "prompt_extend": prompt_extend,
@@ -582,11 +592,11 @@ class WanxModel(VideoGenModel):
             payload["parameters"]["ratio"] = ratio
         elif resolution:
             payload["parameters"]["resolution"] = resolution
-        
+
         # Add optional parameters
         if negative_prompt:
             payload["input"]["negative_prompt"] = negative_prompt
-        if audio_url:
+        if audio_url and not is_wan27:
             payload["input"]["audio_url"] = audio_url
             del payload["parameters"]["audio"]  # audio_url takes precedence
         if seed:

--- a/src/models/wanx.py
+++ b/src/models/wanx.py
@@ -675,13 +675,23 @@ class WanxModel(VideoGenModel):
         if extra_headers:
             headers.update(dict(extra_headers))
 
-        input_key = "reference_image_urls" if model_name.startswith("wan2.7-") else "reference_video_urls"
+        # wan2.7 R2V uses the unified DashScope media format: input.media is a
+        # list of typed {"type", "url"} objects (reference sheets map to
+        # "reference_image"). The legacy wan2.6 protocol takes a plain string
+        # array under input.reference_urls. The old field names
+        # ("reference_image_urls" / "reference_video_urls") are accepted by
+        # neither and fail async validation with "Field required: input.media".
+        input_payload = {"prompt": prompt}
+        if model_name.startswith("wan2.7-"):
+            input_payload["media"] = [
+                {"type": "reference_image", "url": url} for url in ref_video_urls
+            ]
+        else:
+            input_payload["reference_urls"] = list(ref_video_urls)
+
         payload = {
             "model": model_name,
-            "input": {
-                "prompt": prompt,
-                input_key: ref_video_urls
-            },
+            "input": input_payload,
             "parameters": {
                 "duration": duration,
                 "audio": audio,

--- a/src/utils/media_refs.py
+++ b/src/utils/media_refs.py
@@ -22,6 +22,18 @@ MEDIA_REF_DATA_URI = "data_uri"
 MEDIA_REF_UNKNOWN = "unknown"
 
 
+def _normalize_separators(value: str) -> str:
+    """Normalize path separators to POSIX style.
+
+    Media refs are written with os.path.relpath / os.path.join (e.g. in
+    comic_gen asset generation), which produce backslash separators on
+    Windows such as ``assets\\characters\\foo.png``. Prefix-based
+    classification must not depend on the platform that wrote the ref, so
+    both separator styles are treated identically.
+    """
+    return value.replace("\\", "/")
+
+
 def _project_root(project_root: Optional[str] = None) -> Path:
     if project_root:
         return Path(project_root).resolve()
@@ -67,6 +79,11 @@ def classify_media_ref(
     if raw.startswith(("http://", "https://")):
         return MEDIA_REF_REMOTE_URL
 
+    # Refs written by os.path.relpath/os.path.join on Windows use
+    # backslashes ("assets\characters\foo.png"); normalize before matching
+    # POSIX-style prefixes and path checks.
+    raw = _normalize_separators(raw)
+
     output_root = _output_root(project_root)
     if os.path.isabs(raw):
         return MEDIA_REF_LOCAL_PATH if _is_under(Path(raw), output_root) else MEDIA_REF_UNKNOWN
@@ -90,7 +107,7 @@ def resolve_local_media_path(value: str, *, project_root: Optional[str] = None) 
     if classify_media_ref(value, project_root=project_root) != MEDIA_REF_LOCAL_PATH:
         return None
 
-    raw = value.strip()
+    raw = _normalize_separators(value.strip())
     output_root = os.path.realpath(str(_output_root(project_root)))
 
     if os.path.isabs(raw):


### PR DESCRIPTION
## 背景

分镜台使用 wan2.7 系列模型生成视频时 100% 失败，前端只显示"生成失败"，后端日志两处根因：

1. Windows 上媒体引用以 `\` 分隔，被媒体分类器判为 UNKNOWN，R2V 生成请求直接报错
2. wan2.7 的 API 已统一改用 `input.media` 数组格式，而代码仍发送 2.1–2.6 的老字段
   - r2v：发送了不存在的 `input.reference_image_urls` / `input.reference_video_urls`
   - i2v：发送了 legacy 的 `input.img_url`
   - 两者均被 DashScope 异步校验拒绝：`InvalidParameter - Field required: input.media`

## 改动

- `src/utils/media_refs.py`：媒体引用分隔符统一归一化为 POSIX（`\` → `/`），修复 Windows 下引用无法分类的问题
- `src/models/wanx.py`：
  - wan2.7-r2v → `input.media`（`{"type": "reference_image", "url": ...}` 数组）
  - wan2.7-i2v → `input.media`（`first_frame`，可选 `driving_audio`，可驱动口型）
  - 2.5 / 2.6 老模型保持 `img_url` / `reference_urls` 兼容不变
- `src/apps/comic_gen/pipeline.py`：任务失败时写入 `task.error`，成功时清除，方便定位问题

## 验证

- Windows 反斜杠引用：分类、路径解析、data-URI 兜底链路全部跑通
- 请求体：monkeypatch 抓包断言 2.7/2.6 两代模型的 payload 格式正确
- 实机确认 wan2.7-r2v、wan2.7-i2v 均能正常生成视频
