### PR TITLE
fix(audio): normalize CosyVoice instructions and report batch failures

### DIFF
--- a/src/apps/comic_gen/api.py
+++ b/src/apps/comic_gen/api.py
@@ -3119,8 +3119,24 @@ def generate_dialogue_audio_batch(script_id: str):
                 skipped += 1
                 continue
             try:
-                pipeline.generate_dialogue_line(script_id, frame.id)
-                generated += 1
+                updated_script = pipeline.generate_dialogue_line(script_id, frame.id)
+                updated_frame = next(
+                    (candidate for candidate in updated_script.frames if candidate.id == frame.id),
+                    None,
+                )
+                if (
+                    updated_frame
+                    and updated_frame.audio_url
+                    and not dialogue_audio_is_stale(updated_frame, speaker)
+                ):
+                    generated += 1
+                else:
+                    failed += 1
+                    error = getattr(updated_frame, "audio_error", None) if updated_frame else None
+                    logger.error(
+                        f"[batch_dialogue_audio] frame={frame.id} generation did not "
+                        f"produce current audio: {error or 'unknown error'}"
+                    )
             except Exception as exc:
                 logger.error(f"[batch_dialogue_audio] frame={frame.id} error={exc}")
                 failed += 1

--- a/src/audio/tts.py
+++ b/src/audio/tts.py
@@ -7,6 +7,7 @@ See: https://help.aliyun.com/zh/model-studio/cosyvoice-python-sdk
 """
 import os
 import logging
+import re
 from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -46,8 +47,18 @@ VOICES = {
     'loongstella': {'model_id': 'loongstella_v2', 'name': 'Stella (English Female)', 'gender': 'Female', 'model': 'cosyvoice-v2'},
     'loongbella': {'model_id': 'loongbella_v2', 'name': 'Bella (English Female)', 'gender': 'Female', 'model': 'cosyvoice-v2'},
     # === cosyvoice-v3 voices (require cosyvoice-v3-flash or cosyvoice-v3-plus) ===
-    'longanyang': {'model_id': 'longanyang', 'name': '龙安阳 (阳光少年)', 'gender': 'Male', 'model': 'cosyvoice-v3-flash'},
-    'longanhuan': {'model_id': 'longanhuan', 'name': '龙安欢 (活力女)', 'gender': 'Female', 'model': 'cosyvoice-v3-flash'},
+    'longanyang': {
+        'model_id': 'longanyang', 'name': '龙安阳 (阳光少年)',
+        'gender': 'Male', 'model': 'cosyvoice-v3-flash',
+        # This benchmark voice rejects free-form instructions. DashScope
+        # requires exactly: 你说话的情感是<supported emotion>。
+        'supports_instruction': True, 'instruction_mode': 'strict_emotion',
+    },
+    'longanhuan': {
+        'model_id': 'longanhuan', 'name': '龙安欢 (活力女)',
+        'gender': 'Female', 'model': 'cosyvoice-v3-flash',
+        'supports_instruction': True, 'instruction_mode': 'strict_emotion',
+    },
     # === Qwen3-TTS voices (PR-3g Stage A — added 2026-05-25 from official doc)
     # Use qwen3-tts-flash for standard / qwen3-tts-instruct-flash for instructions
     # control. Voice IDs are case-sensitive (Cherry not cherry). Supports 10 langs:
@@ -216,15 +227,21 @@ class TTSProcessor:
             'pitch_rate': pitch_rate,
             'volume': volume,
         }
-        # Pass instructions only if voice supports it (v3-flash / v3.5-*).
-        # SDK will reject unknown kwargs, so gate explicitly.
-        if instructions and self._voice_supports_instruction(voice):
-            synth_kwargs['instructions'] = instructions
+        normalized_instruction = self._normalize_cosyvoice_instruction(
+            voice, instructions
+        )
+
+        # DashScope's CosyVoice SDK names this constructor argument
+        # ``instruction`` (singular).  Qwen3's separate API uses
+        # ``instructions`` (plural), so keep the provider-specific spelling
+        # here instead of forwarding our public parameter name verbatim.
+        if normalized_instruction:
+            synth_kwargs['instruction'] = normalized_instruction
 
         logger.info(
             f"CosyVoice synth: model={model}, voice='{voice}' "
             f"(rate={speech_rate}, pitch={pitch_rate}, vol={volume}, "
-            f"instr={'yes' if instructions else 'no'})"
+            f"instr={'yes' if normalized_instruction else 'no'})"
         )
         logger.info(f"Text: {text[:100]}{'...' if len(text) > 100 else ''}")
 
@@ -244,6 +261,62 @@ class TTSProcessor:
             f"delay={first_package_delay}ms, total={duration:.2f}s -> {output_path}"
         )
         return output_path, first_package_delay, request_id
+
+    def _normalize_cosyvoice_instruction(
+        self, voice: str, instructions: Optional[str]
+    ) -> Optional[str]:
+        """Convert generic UI directions to the format required by a voice.
+
+        Most instruction-capable CosyVoice models accept natural language.
+        A small set of v3 benchmark voices (including ``longanyang`` and
+        ``longanhuan``) only accepts one of seven emotion values in a fixed
+        Chinese sentence. Passing LumenX's generic ``情绪：…；演绎：…`` string
+        makes DashScope fail with engine code 428, so reduce it to the closest
+        supported emotion. Unknown directions are omitted rather than making
+        the whole dialogue synthesis fail.
+        """
+        if not instructions or not self._voice_supports_instruction(voice):
+            return None
+
+        meta = self._voice_meta(voice)
+        if meta.get('instruction_mode') != 'strict_emotion':
+            return instructions
+
+        value = instructions.strip().lower()
+        canonical = re.fullmatch(
+            r"你说话的情感是(neutral|fearful|angry|sad|surprised|happy|disgusted)。",
+            value,
+        )
+        if canonical:
+            return f"你说话的情感是{canonical.group(1)}。"
+
+        # Storyboard extraction emits "情绪：…；演绎：…". Prefer the explicit
+        # emotion field over delivery keywords when they conflict.
+        explicit_emotion = re.search(
+            r"(?:情绪|emotion)\s*[:：]\s*([^;；,，\n]+)",
+            value,
+        )
+        emotion_source = explicit_emotion.group(1) if explicit_emotion else value
+        emotion_keywords = (
+            ('fearful', ('fearful', '恐惧', '害怕', '惊恐', '恐慌', '焦急', '紧张', '不安')),
+            ('angry', ('angry', '愤怒', '生气', '恼怒', '气愤')),
+            ('sad', ('sad', '悲伤', '难过', '伤心', '哀伤', '沮丧')),
+            ('surprised', ('surprised', '惊讶', '吃惊', '震惊', '意外')),
+            ('happy', ('happy', '开心', '高兴', '喜悦', '兴奋', '欢快')),
+            ('disgusted', ('disgusted', '厌恶', '反感', '恶心', '嫌弃')),
+            ('neutral', ('neutral', '平静', '中性', '冷静', '淡定', '平稳')),
+        )
+        for emotion, keywords in emotion_keywords:
+            if any(keyword in emotion_source for keyword in keywords):
+                return f"你说话的情感是{emotion}。"
+
+        logger.warning(
+            "Ignoring unsupported free-form instruction for strict CosyVoice "
+            "voice '%s': %s",
+            voice,
+            instructions[:100],
+        )
+        return None
 
     def _synthesize_qwen3(
         self, text: str, output_path: str, voice: str,

--- a/tests/test_dialogue_audio.py
+++ b/tests/test_dialogue_audio.py
@@ -1,0 +1,197 @@
+"""Regression tests for dialogue TTS generation and batch accounting."""
+
+import json
+import os
+import time
+
+import pytest
+
+from src.audio.tts import TTSProcessor
+from src.apps.comic_gen.models import (
+    Character,
+    GenerationStatus,
+    Script,
+    StoryboardFrame,
+)
+
+
+@pytest.fixture
+def comic_api():
+    """Import the API without letting its .env bootstrap leak across tests."""
+    environment = os.environ.copy()
+    try:
+        from src.apps.comic_gen import api
+        yield api
+    finally:
+        os.environ.clear()
+        os.environ.update(environment)
+
+
+def test_cosyvoice_normalizes_and_uses_singular_instruction(monkeypatch, tmp_path):
+    """Strict v3 voices need canonical emotion text in singular ``instruction``."""
+    import dashscope.audio.tts_v2 as tts_v2
+
+    captured = {}
+
+    class FakeSpeechSynthesizer:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def call(self, text):
+            captured["text"] = text
+            return b"fake-mp3"
+
+        def get_last_request_id(self):
+            return "request-1"
+
+        def get_first_package_delay(self):
+            return 12
+
+    monkeypatch.setattr(tts_v2, "SpeechSynthesizer", FakeSpeechSynthesizer)
+
+    processor = object.__new__(TTSProcessor)
+    processor.model = "cosyvoice-v3-flash"
+    processor.voice = "longanyang"
+    output_path = tmp_path / "dialogue.mp3"
+
+    processor._synthesize_cosyvoice(
+        "师父，盒子里的经书不见了！",
+        str(output_path),
+        voice="longanyang",
+        instructions="情绪：焦急；演绎：急促、音量偏高、语气紧张",
+    )
+
+    assert captured["instruction"] == "你说话的情感是fearful。"
+    assert "instructions" not in captured
+    assert output_path.read_bytes() == b"fake-mp3"
+
+
+def test_cosyvoice_omits_unsupported_free_form_for_strict_voice(monkeypatch, tmp_path):
+    """An unknown free-form direction must not turn into DashScope error 428."""
+    import dashscope.audio.tts_v2 as tts_v2
+
+    captured = {}
+
+    class FakeSpeechSynthesizer:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def call(self, text):
+            return b"fake-mp3"
+
+        def get_last_request_id(self):
+            return "request-2"
+
+        def get_first_package_delay(self):
+            return 10
+
+    monkeypatch.setattr(tts_v2, "SpeechSynthesizer", FakeSpeechSynthesizer)
+
+    processor = object.__new__(TTSProcessor)
+    processor.model = "cosyvoice-v3-flash"
+    processor.voice = "longanyang"
+
+    processor._synthesize_cosyvoice(
+        "测试",
+        str(tmp_path / "dialogue.mp3"),
+        voice="longanyang",
+        instructions="像电影预告片一样演绎",
+    )
+
+    assert "instruction" not in captured
+    assert "instructions" not in captured
+
+
+def test_strict_voice_prefers_explicit_emotion_over_delivery_keywords():
+    processor = object.__new__(TTSProcessor)
+    processor.model = "cosyvoice-v3-flash"
+    processor.voice = "longanyang"
+
+    result = processor._normalize_cosyvoice_instruction(
+        "longanyang",
+        "情绪：平静；演绎：兴奋地加快语速",
+    )
+
+    assert result == "你说话的情感是neutral。"
+
+
+def test_strict_voice_preserves_canonical_instruction():
+    processor = object.__new__(TTSProcessor)
+    processor.model = "cosyvoice-v3-flash"
+    processor.voice = "longanyang"
+
+    result = processor._normalize_cosyvoice_instruction(
+        "longanyang",
+        "你说话的情感是HAPPY。",
+    )
+
+    assert result == "你说话的情感是happy。"
+
+
+def test_free_form_cosyvoice_instruction_passes_through():
+    processor = object.__new__(TTSProcessor)
+    processor.model = "cosyvoice-v3.5-plus"
+    processor.voice = "custom-voice"
+
+    result = processor._normalize_cosyvoice_instruction(
+        "custom-voice",
+        "像电影预告片一样，低沉而有力量地说。",
+    )
+
+    assert result == "像电影预告片一样，低沉而有力量地说。"
+
+
+def test_batch_counts_internal_tts_failure_as_failed(monkeypatch, comic_api):
+    """A swallowed TTS exception must not be reported to the UI as generated."""
+    character = Character(
+        id="character-1",
+        name="阿石",
+        description="少年行脚僧",
+        voice_id="longanyang",
+    )
+    frame = StoryboardFrame(
+        id="frame-1",
+        scene_id="scene-1",
+        character_ids=[character.id],
+        dialogue="师父，盒子里的经书不见了！",
+        speaker=character.name,
+    )
+    now = time.time()
+    script = Script(
+        id="script-1",
+        title="测试",
+        original_text="测试",
+        characters=[character],
+        frames=[frame],
+        created_at=now,
+        updated_at=now,
+    )
+
+    class FakePipeline:
+        def get_script(self, script_id):
+            assert script_id == script.id
+            return script
+
+        def generate_dialogue_line(self, script_id, frame_id):
+            assert script_id == script.id
+            assert frame_id == frame.id
+            frame.status = GenerationStatus.FAILED
+            frame.audio_url = None
+            frame.audio_error = "simulated TTS failure"
+            return script
+
+    class LocalOnlyUploader:
+        is_configured = False
+
+    monkeypatch.setattr(comic_api, "pipeline", FakePipeline())
+    monkeypatch.setattr(comic_api, "OSSImageUploader", LocalOnlyUploader)
+
+    response = comic_api.generate_dialogue_audio_batch(script.id)
+    payload = json.loads(response.body)
+
+    assert payload["_batch_stats"] == {
+        "generated": 0,
+        "skipped": 0,
+        "failed": 1,
+        "no_voice": 0,
+    }


### PR DESCRIPTION
## Summary

- Pass CosyVoice emotion control through DashScope's singular `instruction` SDK argument while keeping Qwen3's separate `instructions` API unchanged.
- Normalize generic storyboard dialogue directions for the strict `longanyang` and `longanhuan` voices into DashScope's supported seven-emotion format. Unsupported free-form directions are omitted instead of failing the entire synthesis with engine error 428.
- Count a batch dialogue item as generated only when the returned frame contains current audio. Internally handled TTS failures are now reported as failed instead of being misreported as successful.

## Root cause

`dashscope.audio.tts_v2.SpeechSynthesizer` accepts `instruction` (singular), but the CosyVoice path passed `instructions` (plural). After correcting that argument, the strict v3 benchmark voices still rejected LumenX's generic `情绪：...；演绎：...` text because these voices require the exact form `你说话的情感是<emotion>。`.

Separately, the audio layer records provider errors on the frame rather than re-raising them. The batch endpoint treated every non-throwing call as successful, even when no audio was produced.

DashScope voice format reference: https://help.aliyun.com/zh/model-studio/cosyvoice-voice-list

## Test plan

- [x] `python -m pytest -q` — 216 passed
- [x] `python scripts/validate_model_catalog.py` — passed
- [x] `git diff --check` — passed
- [x] Reproduced the original `longanyang` failure with generic anxious delivery instructions
- [x] Verified successful synthesis after normalization and confirmed a second batch run skips both up-to-date dialogue clips

## Notes

- Backend-only change; no UI screenshots are needed.
- The unrelated OpenAI-compatible client dependency fix is intentionally excluded so this PR remains focused on dialogue audio generation.
