### PR TITLE
fix(deps): install OpenAI SDK for default DashScope LLM

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -5,6 +5,7 @@ python-multipart>=0.0.9
 
 # AI/ML Models
 dashscope>=1.20.0
+openai>=1.0.0
 
 # Data Validation & Processing
 pydantic>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-multipart>=0.0.9
 
 # AI/ML Models
 dashscope>=1.20.0
+openai>=1.0.0
 pywebview>=5.0.0
 
 # Data Validation & Processing
@@ -32,4 +33,3 @@ soundfile>=0.12.0
 # Uncomment if needed:
 # numpy>=1.24.0
 # pillow>=10.0.0
-# openai>=1.0.0  # Required when LLM_PROVIDER=openai

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,14 @@
+from src.apps.comic_gen.llm_adapter import LLMAdapter
+
+
+def test_dashscope_provider_can_initialize_openai_compatible_client(monkeypatch):
+    """DashScope's default path also requires the OpenAI-compatible SDK."""
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+
+    adapter = LLMAdapter()
+    client = adapter._get_client()
+
+    assert adapter.provider == "dashscope"
+    assert client.__class__.__name__ == "OpenAI"
+    assert client.chat.completions is not None


### PR DESCRIPTION
## Summary

- Install the OpenAI Python SDK in both local and Docker dependency manifests.
- Add regression coverage for initializing the default DashScope LLM through its OpenAI-compatible endpoint.

## Root cause

`LLM_PROVIDER` defaults to `dashscope`, and `LLMAdapter._get_client()` uses `openai.OpenAI` for both the DashScope and generic OpenAI-compatible paths. However, `openai` was commented as an optional dependency in `requirements.txt` and was absent from `requirements-docker.txt`.

As a result, a fresh standard installation could start successfully but fail when entity extraction first initialized the LLM client:

```text
openai package not installed. Run: pip install openai>=1.0.0
```

The dependency is now installed by the documented local setup, Docker builds, and Backend CI. Alibaba Cloud's compatible-mode SDK instructions also require the OpenAI Python SDK: https://help.aliyun.com/zh/model-studio/install-sdk/

## Test plan

- [x] `.venv/bin/python -m pytest -q` — 210 passed
- [x] `.venv/bin/python scripts/validate_model_catalog.py` — passed
- [x] `git diff --check` — passed

## Notes

- Backend dependency fix only; no UI screenshots are needed.
- This is intentionally separate from the dialogue-audio fix in #68.
